### PR TITLE
Address pre-existing lint findings surfaced by golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,20 +95,7 @@ linters:
     rules:
       - linters:
           - mnd
-          - goconst
         path: _test\.go
-      - path: internal/infra/sqlite/
-        linters:
-          - noctx
-      - path: internal/infra/http/api/router_test\.go
-        linters:
-          - noctx
-      - path: internal/infra/http/api/login\.go
-        linters:
-          - gosec
-      - path: internal/testserver/
-        linters:
-          - gosec
       - path: pkg/golinters/errcheck.go
         text: 'SA1019: errCfg.Exclude is deprecated: use ExcludeFunctions instead'
       - path: pkg/commands/run.go

--- a/internal/app/auth/service_test.go
+++ b/internal/app/auth/service_test.go
@@ -13,6 +13,12 @@ import (
 	mocks "github.com/cubny/lite-reader/internal/mocks/app/auth"
 )
 
+const (
+	tcSuccess    = "success"
+	testEmail    = "test@example.com"
+	testPassword = "password123"
+)
+
 func TestService_Signup(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -22,14 +28,14 @@ func TestService_Signup(t *testing.T) {
 		errMsg    string
 	}{
 		{
-			name: "success",
+			name: tcSuccess,
 			command: &auth.SignupCommand{
-				Email:    "test@example.com",
-				Password: "password123",
+				Email:    testEmail,
+				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
-				r.EXPECT().GetUserByEmail("test@example.com").Return(nil, errors.New("not found"))
-				r.EXPECT().CreateUser("test@example.com", gomock.Any()).Return(nil)
+				r.EXPECT().GetUserByEmail(testEmail).Return(nil, errors.New("not found"))
+				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -37,7 +43,7 @@ func TestService_Signup(t *testing.T) {
 			name: "error - email already exists",
 			command: &auth.SignupCommand{
 				Email:    "existing@example.com",
-				Password: "password123",
+				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
 				r.EXPECT().GetUserByEmail("existing@example.com").Return(&auth.User{}, nil)
@@ -48,12 +54,12 @@ func TestService_Signup(t *testing.T) {
 		{
 			name: "error - create user fails",
 			command: &auth.SignupCommand{
-				Email:    "test@example.com",
-				Password: "password123",
+				Email:    testEmail,
+				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
-				r.EXPECT().GetUserByEmail("test@example.com").Return(nil, errors.New("not found"))
-				r.EXPECT().CreateUser("test@example.com", gomock.Any()).Return(errors.New("db error"))
+				r.EXPECT().GetUserByEmail(testEmail).Return(nil, errors.New("not found"))
+				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(errors.New("db error"))
 			},
 			wantErr: true,
 			errMsg:  "db error",
@@ -92,16 +98,16 @@ func TestService_Login(t *testing.T) {
 		errMsg    string
 	}{
 		{
-			name: "success",
+			name: tcSuccess,
 			command: &auth.LoginCommand{
-				Email:    "test@example.com",
-				Password: "password123",
+				Email:    testEmail,
+				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
-				hashedPassword, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
+				hashedPassword, _ := bcrypt.GenerateFromPassword([]byte(testPassword), bcrypt.DefaultCost)
 				user := &auth.User{
 					ID:       1,
-					Email:    "test@example.com",
+					Email:    testEmail,
 					Password: string(hashedPassword),
 				}
 				session := &auth.Session{
@@ -109,7 +115,7 @@ func TestService_Login(t *testing.T) {
 					RefreshToken: "refresh-token",
 					ExpiresAt:    time.Now().Add(time.Hour),
 				}
-				r.EXPECT().GetUserByEmail("test@example.com").Return(user, nil)
+				r.EXPECT().GetUserByEmail(testEmail).Return(user, nil)
 				r.EXPECT().CreateSession(user.ID).Return(session, nil)
 			},
 			wantErr: false,
@@ -118,7 +124,7 @@ func TestService_Login(t *testing.T) {
 			name: "error - user not found",
 			command: &auth.LoginCommand{
 				Email:    "nonexistent@example.com",
-				Password: "password123",
+				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
 				r.EXPECT().GetUserByEmail("nonexistent@example.com").Return(nil, errors.New("not found"))
@@ -129,17 +135,17 @@ func TestService_Login(t *testing.T) {
 		{
 			name: "error - invalid password",
 			command: &auth.LoginCommand{
-				Email:    "test@example.com",
+				Email:    testEmail,
 				Password: "wrongpassword",
 			},
 			mockSetup: func(r *mocks.Repository) {
-				hashedPassword := "$2a$10$abcdefghijklmnopqrstuvwxyz" // pre-hashed "password123"
+				hashedPassword := "$2a$10$abcdefghijklmnopqrstuvwxyz" // pre-hashed testPassword
 				user := &auth.User{
 					ID:       1,
-					Email:    "test@example.com",
+					Email:    testEmail,
 					Password: hashedPassword,
 				}
-				r.EXPECT().GetUserByEmail("test@example.com").Return(user, nil)
+				r.EXPECT().GetUserByEmail(testEmail).Return(user, nil)
 			},
 			wantErr: true,
 			errMsg:  "invalid email or password",
@@ -182,7 +188,7 @@ func TestService_GetSession(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:  "success",
+			name:  tcSuccess,
 			token: "valid-token",
 			mockSetup: func(r *mocks.Repository) {
 				session := &auth.Session{
@@ -234,7 +240,7 @@ func TestService_GetAllUsers(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name: "success",
+			name: tcSuccess,
 			mockSetup: func(r *mocks.Repository) {
 				users := []*auth.User{
 					{ID: 1, Email: "user1@example.com"},

--- a/internal/app/feed/service_test.go
+++ b/internal/app/feed/service_test.go
@@ -13,6 +13,16 @@ import (
 	mocks "github.com/cubny/lite-reader/internal/mocks/app/feed"
 )
 
+const (
+	exampleFeedTitle    = "Example Feed"
+	exampleFeedDesc     = "Example Description"
+	exampleFeedDesc2    = "Example Description 2"
+	exampleFeedLink     = "https://example.com"
+	exampleFeedURL      = "https://example.com/feed"
+	exampleFeedLinkTypo = "https//example.com"
+	exampleFeedLang     = "en"
+)
+
 func TestServiceImpl_AddFeed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	tests := []struct {
@@ -32,11 +42,11 @@ func TestServiceImpl_AddFeed(t *testing.T) {
 			name:          "success",
 			parseURLError: nil,
 			parseURLResult: &gofeed.Feed{
-				Title:       "Example Feed",
-				Description: "Example Description",
-				Link:        "https://example.com",
-				FeedLink:    "https://example.com/feed",
-				Language:    "en",
+				Title:       exampleFeedTitle,
+				Description: exampleFeedDesc,
+				Link:        exampleFeedLink,
+				FeedLink:    exampleFeedURL,
+				Language:    exampleFeedLang,
 				Items:       []*gofeed.Item{},
 			},
 			finderCalled: false,
@@ -47,9 +57,9 @@ func TestServiceImpl_AddFeed(t *testing.T) {
 			repoError:    nil,
 			want: &feed.Feed{
 				ID:          1,
-				Title:       "Example Feed",
-				Link:        "https//example.com",
-				URL:         "https://example.com/feed",
+				Title:       exampleFeedTitle,
+				Link:        exampleFeedLinkTypo,
+				URL:         exampleFeedURL,
 				UnreadCount: 0,
 			},
 			wantErr: false,
@@ -123,7 +133,7 @@ func TestServiceImpl_AddFeed(t *testing.T) {
 			}
 
 			s := feed.NewService(repo, parser, finder)
-			cmd := &feed.AddFeedCommand{URL: "https://example.com/feed"}
+			cmd := &feed.AddFeedCommand{URL: exampleFeedURL}
 			got, err := s.AddFeed(cmd)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ServiceImpl.AddFeed() error = %v, wantErr %v", err, tt.wantErr)
@@ -139,22 +149,22 @@ func TestServiceImpl_AddFeed(t *testing.T) {
 		repoMock.EXPECT().AddFeed(gomock.Any()).Return(1, nil)
 
 		parserMock := mocks.NewParser(ctrl)
-		parserMock.EXPECT().ParseURL("https://example.com").Return(nil, gofeed.ErrFeedTypeNotDetected)
-		parserMock.EXPECT().ParseURL("https://example.com/feed").Return(nil, assert.AnError)
+		parserMock.EXPECT().ParseURL(exampleFeedLink).Return(nil, gofeed.ErrFeedTypeNotDetected)
+		parserMock.EXPECT().ParseURL(exampleFeedURL).Return(nil, assert.AnError)
 		parserMock.EXPECT().ParseURL("https://example.com/feed2").Return(&gofeed.Feed{
-			Title:       "Example Feed",
-			Description: "Example Description",
-			Link:        "https://example.com",
-			FeedLink:    "https://example.com/feed",
-			Language:    "en",
+			Title:       exampleFeedTitle,
+			Description: exampleFeedDesc,
+			Link:        exampleFeedLink,
+			FeedLink:    exampleFeedURL,
+			Language:    exampleFeedLang,
 			Items:       []*gofeed.Item{},
 		}, nil)
 
 		finderMock := mocks.NewFinder(ctrl)
-		finderMock.EXPECT().FindFeeds(gomock.Any()).Return([]string{"https://example.com/feed", "https://example.com/feed2"}, nil)
+		finderMock.EXPECT().FindFeeds(gomock.Any()).Return([]string{exampleFeedURL, "https://example.com/feed2"}, nil)
 
 		s := feed.NewService(repoMock, parserMock, finderMock)
-		cmd := &feed.AddFeedCommand{URL: "https://example.com"}
+		cmd := &feed.AddFeedCommand{URL: exampleFeedLink}
 		_, err := s.AddFeed(cmd)
 		assert.NoError(t, err)
 	})
@@ -198,22 +208,22 @@ func TestServiceImpl_FetchItems(t *testing.T) {
 			name: "success",
 			parser: Parser{
 				result: &gofeed.Feed{
-					Title:       "Example Feed",
-					Description: "Example Description",
-					Link:        "https://example.com",
-					FeedLink:    "https://example.com/feed",
-					Language:    "en",
+					Title:       exampleFeedTitle,
+					Description: exampleFeedDesc,
+					Link:        exampleFeedLink,
+					FeedLink:    exampleFeedURL,
+					Language:    exampleFeedLang,
 					Items: []*gofeed.Item{
 						{
 							Title:           "Example Item",
-							Description:     "Example Description",
+							Description:     exampleFeedDesc,
 							Link:            "https://example.com/item",
 							Published:       "2021-01-01T00:00:00Z",
 							PublishedParsed: &samplePublishedParsed,
 						},
 						{
 							Title:           "Example Item 2",
-							Description:     "Example Description 2",
+							Description:     exampleFeedDesc2,
 							Link:            "https://example.com/item2",
 							Published:       "2021-01-01T00:00:00Z",
 							PublishedParsed: &samplePublishedParsed,
@@ -226,9 +236,9 @@ func TestServiceImpl_FetchItems(t *testing.T) {
 			repo: Repo{
 				result: &feed.Feed{
 					ID:          1,
-					Title:       "Example Feed",
-					Link:        "https//example.com",
-					URL:         "https://example.com/feed",
+					Title:       exampleFeedTitle,
+					Link:        exampleFeedLinkTypo,
+					URL:         exampleFeedURL,
 					UnreadCount: 0,
 				},
 				error: nil,
@@ -236,19 +246,19 @@ func TestServiceImpl_FetchItems(t *testing.T) {
 			want: []*item.Item{
 				{
 					Title:     "Example Item",
-					Desc:      "Example Description",
+					Desc:      exampleFeedDesc,
 					Link:      "https://example.com/item",
 					Timestamp: samplePublishedParsed,
-					Dir:       "Example Description",
+					Dir:       exampleFeedDesc,
 					IsNew:     true,
 					Starred:   false,
 				},
 				{
 					Title:     "Example Item 2",
-					Desc:      "Example Description 2",
+					Desc:      exampleFeedDesc2,
 					Link:      "https://example.com/item2",
 					Timestamp: samplePublishedParsed,
-					Dir:       "Example Description 2",
+					Dir:       exampleFeedDesc2,
 					IsNew:     true,
 					Starred:   false,
 				},
@@ -279,9 +289,9 @@ func TestServiceImpl_FetchItems(t *testing.T) {
 			repo: Repo{
 				result: &feed.Feed{
 					ID:          1,
-					Title:       "Example Feed",
-					Link:        "https//example.com",
-					URL:         "https://example.com/feed",
+					Title:       exampleFeedTitle,
+					Link:        exampleFeedLinkTypo,
+					URL:         exampleFeedURL,
 					UnreadCount: 0,
 				},
 				error: nil,

--- a/internal/app/item/service_test.go
+++ b/internal/app/item/service_test.go
@@ -11,6 +11,15 @@ import (
 	mocks "github.com/cubny/lite-reader/internal/mocks/app/item"
 )
 
+const (
+	tcHappy      = "happy"
+	tcRepoErrors = "repo errors"
+	itemTitle    = "title"
+	itemDesc     = "desc"
+	itemDir      = "dir"
+	itemLink     = "link"
+)
+
 func TestServiceImpl_GetUnreadItems(t *testing.T) {
 	type Repo struct {
 		result []*item.Item
@@ -23,15 +32,15 @@ func TestServiceImpl_GetUnreadItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				result: []*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "desc",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     itemTitle,
+						Desc:      itemDesc,
+						Dir:       itemDir,
+						Link:      itemLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: time.Now(),
@@ -42,10 +51,10 @@ func TestServiceImpl_GetUnreadItems(t *testing.T) {
 			want: []*item.Item{
 				{
 					ID:        1,
-					Title:     "title",
-					Desc:      "desc",
-					Dir:       "dir",
-					Link:      "link",
+					Title:     itemTitle,
+					Desc:      itemDesc,
+					Dir:       itemDir,
+					Link:      itemLink,
 					IsNew:     true,
 					Starred:   false,
 					Timestamp: time.Now(),
@@ -53,7 +62,7 @@ func TestServiceImpl_GetUnreadItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				result: nil,
 				err:    assert.AnError,
@@ -97,15 +106,15 @@ func TestServiceImpl_GetStarredItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				result: []*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "desc",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     itemTitle,
+						Desc:      itemDesc,
+						Dir:       itemDir,
+						Link:      itemLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: time.Now(),
@@ -116,10 +125,10 @@ func TestServiceImpl_GetStarredItems(t *testing.T) {
 			want: []*item.Item{
 				{
 					ID:        1,
-					Title:     "title",
-					Desc:      "desc",
-					Dir:       "dir",
-					Link:      "link",
+					Title:     itemTitle,
+					Desc:      itemDesc,
+					Dir:       itemDir,
+					Link:      itemLink,
 					IsNew:     true,
 					Starred:   false,
 					Timestamp: time.Now(),
@@ -127,7 +136,7 @@ func TestServiceImpl_GetStarredItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				result: nil,
 				err:    assert.AnError,
@@ -175,15 +184,15 @@ func TestServiceImpl_GetFeedItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				result: []*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "desc",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     itemTitle,
+						Desc:      itemDesc,
+						Dir:       itemDir,
+						Link:      itemLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: time.Now(),
@@ -197,10 +206,10 @@ func TestServiceImpl_GetFeedItems(t *testing.T) {
 			want: []*item.Item{
 				{
 					ID:        1,
-					Title:     "title",
-					Desc:      "desc",
-					Dir:       "dir",
-					Link:      "link",
+					Title:     itemTitle,
+					Desc:      itemDesc,
+					Dir:       itemDir,
+					Link:      itemLink,
 					IsNew:     true,
 					Starred:   false,
 					Timestamp: time.Now(),
@@ -208,7 +217,7 @@ func TestServiceImpl_GetFeedItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				result: nil,
 				err:    assert.AnError,
@@ -258,7 +267,7 @@ func TestServiceImpl_UpsertItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				err: nil,
 			},
@@ -267,10 +276,10 @@ func TestServiceImpl_UpsertItems(t *testing.T) {
 				Items: []*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "desc",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     itemTitle,
+						Desc:      itemDesc,
+						Dir:       itemDir,
+						Link:      itemLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: time.Now(),
@@ -279,7 +288,7 @@ func TestServiceImpl_UpsertItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				err: assert.AnError,
 			},
@@ -288,10 +297,10 @@ func TestServiceImpl_UpsertItems(t *testing.T) {
 				Items: []*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "desc",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     itemTitle,
+						Desc:      itemDesc,
+						Dir:       itemDir,
+						Link:      itemLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: time.Now(),
@@ -332,7 +341,7 @@ func TestServiceImpl_UpdateItem(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				err: nil,
 			},
@@ -343,7 +352,7 @@ func TestServiceImpl_UpdateItem(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				err: assert.AnError,
 			},
@@ -384,7 +393,7 @@ func TestServiceImpl_ReadFeedItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				err: nil,
 			},
@@ -393,7 +402,7 @@ func TestServiceImpl_ReadFeedItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				err: assert.AnError,
 			},
@@ -432,7 +441,7 @@ func TestServiceImpl_UnreadFeedItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				err: nil,
 			},
@@ -441,7 +450,7 @@ func TestServiceImpl_UnreadFeedItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				err: assert.AnError,
 			},
@@ -478,7 +487,7 @@ func TestServiceImpl_GetStarredItemsCount(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				result: 1,
 				err:    nil,
@@ -487,7 +496,7 @@ func TestServiceImpl_GetStarredItemsCount(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				result: 0,
 				err:    assert.AnError,
@@ -527,7 +536,7 @@ func TestServiceImpl_GetUnreadItemsCount(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				result: 1,
 				err:    nil,
@@ -536,7 +545,7 @@ func TestServiceImpl_GetUnreadItemsCount(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				result: 0,
 				err:    assert.AnError,
@@ -578,7 +587,7 @@ func TestServiceImpl_DeleteFeedItems(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: tcHappy,
 			repo: Repo{
 				err: nil,
 			},
@@ -587,7 +596,7 @@ func TestServiceImpl_DeleteFeedItems(t *testing.T) {
 			}, wantErr: false,
 		},
 		{
-			name: "repo errors",
+			name: tcRepoErrors,
 			repo: Repo{
 				err: assert.AnError,
 			},

--- a/internal/infra/http/api/feed_test.go
+++ b/internal/infra/http/api/feed_test.go
@@ -24,9 +24,9 @@ func TestRouter_addFeed(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodPost,
-			Target:         "/feeds",
+			Target:         feedsPath,
 			ReqBody:        `{"url":"http://valid.url"}`,
 			ExpectedStatus: http.StatusCreated,
 			ExpectedBody: `{"id":1,"title":"title","desc":"description","link":"link","url":"url","updated_at":"` +
@@ -34,9 +34,9 @@ func TestRouter_addFeed(t *testing.T) {
 			MockFn: func(_ *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {
 				f.EXPECT().AddFeed(gomock.Any()).Return(&feed.Feed{
 					ID:          1,
-					Title:       "title",
-					Description: "description",
-					Link:        "link",
+					Title:       feedTitle,
+					Description: feedDesc,
+					Link:        feedLink,
 					URL:         "url",
 					Lang:        "lang",
 					UpdatedAt:   now,
@@ -50,7 +50,7 @@ func TestRouter_addFeed(t *testing.T) {
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - cannot decode request body"}}`,
 			Method:         http.MethodPost,
-			Target:         "/feeds",
+			Target:         feedsPath,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
@@ -59,16 +59,16 @@ func TestRouter_addFeed(t *testing.T) {
 			ExpectedStatus: http.StatusUnprocessableEntity,
 			ExpectedBody:   `{"error":{"code":422,"details":"Invalid params - invalid params"}}`,
 			Method:         http.MethodPost,
-			Target:         "/feeds",
+			Target:         feedsPath,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			ReqBody:        `{"url":"http://valid.url"}`,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500,"details":"Internal error - failed to add feed due to server internal error"}}`,
 			Method:         http.MethodPost,
-			Target:         "/feeds",
+			Target:         feedsPath,
 			MockFn: func(_ *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {
 				f.EXPECT().AddFeed(gomock.Any()).Return(nil, assert.AnError)
 			},
@@ -79,7 +79,7 @@ func TestRouter_addFeed(t *testing.T) {
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - cannot decode request body"}}`,
 			Method:         http.MethodPost,
-			Target:         "/feeds",
+			Target:         feedsPath,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 	}
@@ -99,7 +99,7 @@ func TestRouter_getFeedItems(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodGet,
 			Target:         "/feeds/1/items",
 			ExpectedStatus: http.StatusOK,
@@ -109,10 +109,10 @@ func TestRouter_getFeedItems(t *testing.T) {
 				i.EXPECT().GetFeedItems(gomock.Any()).Return([]*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "description",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     feedTitle,
+						Desc:      feedDesc,
+						Dir:       feedDir,
+						Link:      feedLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: now,
@@ -121,15 +121,15 @@ func TestRouter_getFeedItems(t *testing.T) {
 			},
 		},
 		{
-			Name:           "invalid feed id",
+			Name:           tcInvalidFeedID,
 			Method:         http.MethodGet,
 			Target:         "/feeds/invalid/items",
 			ExpectedStatus: http.StatusUnprocessableEntity,
-			ExpectedBody:   `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`,
+			ExpectedBody:   respInvalidFeedID,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			Method:         http.MethodGet,
 			Target:         "/feeds/1/items",
 			ExpectedStatus: http.StatusInternalServerError,
@@ -155,9 +155,9 @@ func TestRouter_fetchFeedNewItems(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodPut,
-			Target:         "/feeds/1/fetch",
+			Target:         feedFetchPath,
 			ExpectedStatus: http.StatusOK,
 			ExpectedBody: `[{"id":1,"title":"title","dir":"dir","desc":"description","link":"link","is_new":false,"starred":true,"timestamp":"` +
 				now.Format(time.RFC3339Nano) + `"}]`,
@@ -165,10 +165,10 @@ func TestRouter_fetchFeedNewItems(t *testing.T) {
 				f.EXPECT().FetchItems(1).Return([]*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "description",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     feedTitle,
+						Desc:      feedDesc,
+						Dir:       feedDir,
+						Link:      feedLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: now,
@@ -178,10 +178,10 @@ func TestRouter_fetchFeedNewItems(t *testing.T) {
 				i.EXPECT().GetFeedItems(gomock.Any()).Return([]*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "description",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     feedTitle,
+						Desc:      feedDesc,
+						Dir:       feedDir,
+						Link:      feedLink,
 						IsNew:     false,
 						Starred:   true,
 						Timestamp: now,
@@ -190,17 +190,17 @@ func TestRouter_fetchFeedNewItems(t *testing.T) {
 			},
 		},
 		{
-			Name:           "invalid feed id",
+			Name:           tcInvalidFeedID,
 			Method:         http.MethodPut,
 			Target:         "/feeds/invalid/fetch",
 			ExpectedStatus: http.StatusUnprocessableEntity,
-			ExpectedBody:   `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`,
+			ExpectedBody:   respInvalidFeedID,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
 			Name:           "feed service fetch items returns error",
 			Method:         http.MethodPut,
-			Target:         "/feeds/1/fetch",
+			Target:         feedFetchPath,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500,"details":"Internal error - cannot fetch feed items"}}`,
 			MockFn: func(_ *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {
@@ -210,17 +210,17 @@ func TestRouter_fetchFeedNewItems(t *testing.T) {
 		{
 			Name:           "item service returns error",
 			Method:         http.MethodPut,
-			Target:         "/feeds/1/fetch",
+			Target:         feedFetchPath,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500,"details":"Internal error - cannot store feed items"}}`,
 			MockFn: func(i *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {
 				f.EXPECT().FetchItems(1).Return([]*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "description",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     feedTitle,
+						Desc:      feedDesc,
+						Dir:       feedDir,
+						Link:      feedLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: now,
@@ -232,17 +232,17 @@ func TestRouter_fetchFeedNewItems(t *testing.T) {
 		{
 			Name:           "item service get feed items returns error",
 			Method:         http.MethodPut,
-			Target:         "/feeds/1/fetch",
+			Target:         feedFetchPath,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500,"details":"Internal error - cannot get feed items"}}`,
 			MockFn: func(i *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {
 				f.EXPECT().FetchItems(1).Return([]*item.Item{
 					{
 						ID:        1,
-						Title:     "title",
-						Desc:      "description",
-						Dir:       "dir",
-						Link:      "link",
+						Title:     feedTitle,
+						Desc:      feedDesc,
+						Dir:       feedDir,
+						Link:      feedLink,
 						IsNew:     true,
 						Starred:   false,
 						Timestamp: now,
@@ -268,7 +268,7 @@ func TestRouter_readFeedItems(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodPost,
 			Target:         "/feeds/1/read",
 			ExpectedStatus: http.StatusNoContent,
@@ -278,15 +278,15 @@ func TestRouter_readFeedItems(t *testing.T) {
 			},
 		},
 		{
-			Name:           "invalid feed id",
+			Name:           tcInvalidFeedID,
 			Method:         http.MethodPost,
 			Target:         "/feeds/invalid/read",
 			ExpectedStatus: http.StatusUnprocessableEntity,
-			ExpectedBody:   `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`,
+			ExpectedBody:   respInvalidFeedID,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			Method:         http.MethodPost,
 			Target:         "/feeds/1/read",
 			ExpectedStatus: http.StatusInternalServerError,
@@ -311,7 +311,7 @@ func TestRouter_unreadFeedItems(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodPost,
 			Target:         "/feeds/1/unread",
 			ExpectedStatus: http.StatusNoContent,
@@ -321,15 +321,15 @@ func TestRouter_unreadFeedItems(t *testing.T) {
 			},
 		},
 		{
-			Name:           "invalid feed id",
+			Name:           tcInvalidFeedID,
 			Method:         http.MethodPost,
 			Target:         "/feeds/invalid/unread",
 			ExpectedStatus: http.StatusUnprocessableEntity,
-			ExpectedBody:   `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`,
+			ExpectedBody:   respInvalidFeedID,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			Method:         http.MethodPost,
 			Target:         "/feeds/1/unread",
 			ExpectedStatus: http.StatusInternalServerError,
@@ -354,9 +354,9 @@ func TestRouter_DeleteFeed(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodDelete,
-			Target:         "/feeds/1",
+			Target:         feed1Path,
 			ExpectedStatus: http.StatusNoContent,
 			ExpectedBody:   ``,
 			MockFn: func(i *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {
@@ -365,17 +365,17 @@ func TestRouter_DeleteFeed(t *testing.T) {
 			},
 		},
 		{
-			Name:           "invalid feed id",
+			Name:           tcInvalidFeedID,
 			Method:         http.MethodDelete,
 			Target:         "/feeds/invalid",
 			ExpectedStatus: http.StatusUnprocessableEntity,
-			ExpectedBody:   `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`,
+			ExpectedBody:   respInvalidFeedID,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
 			Name:           "item service returns error",
 			Method:         http.MethodDelete,
-			Target:         "/feeds/1",
+			Target:         feed1Path,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500,"details":"Internal error - cannot delete feed"}}`,
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {
@@ -385,7 +385,7 @@ func TestRouter_DeleteFeed(t *testing.T) {
 		{
 			Name:           "feed service returns error",
 			Method:         http.MethodDelete,
-			Target:         "/feeds/1",
+			Target:         feed1Path,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500,"details":"Internal error - cannot delete feed"}}`,
 			MockFn: func(i *mocks.ItemService, f *mocks.FeedService, _ *mocks.AuthService) {

--- a/internal/infra/http/api/item_test.go
+++ b/internal/infra/http/api/item_test.go
@@ -26,7 +26,7 @@ func TestRouter_updateItem(t *testing.T) {
 			ExpectedStatus: http.StatusNoContent,
 			ExpectedBody:   ``,
 			Method:         http.MethodPut,
-			Target:         "/items/1",
+			Target:         item1Path,
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {
 				i.EXPECT().UpdateItem(gomock.Any()).Return(nil)
 			},
@@ -47,15 +47,15 @@ func TestRouter_updateItem(t *testing.T) {
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   `{"error":{"code":400, "details":"Bad Request - cannot decode request body"}}`,
 			Method:         http.MethodPut,
-			Target:         "/items/1",
+			Target:         item1Path,
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			ReqBody:        `{"id": "1", "starred": true, "is_new": true}`,
 			ExpectedStatus: http.StatusInternalServerError,
 			ExpectedBody:   `{"error":{"code":500, "details":"Internal error - cannot update item"}}`,
 			Method:         http.MethodPut,
-			Target:         "/items/1",
+			Target:         item1Path,
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {
 				i.EXPECT().UpdateItem(gomock.Any()).Return(assert.AnError)
 			},
@@ -86,9 +86,9 @@ func TestRouter_getStarredItems(t *testing.T) {
 			},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			ExpectedStatus: http.StatusInternalServerError,
-			ExpectedBody:   `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`,
+			ExpectedBody:   respInternalUnread,
 			Method:         http.MethodGet,
 			Target:         "/items/starred",
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {
@@ -121,9 +121,9 @@ func TestRouter_getUnreadItems(t *testing.T) {
 			},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			ExpectedStatus: http.StatusInternalServerError,
-			ExpectedBody:   `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`,
+			ExpectedBody:   respInternalUnread,
 			Method:         http.MethodGet,
 			Target:         "/items/unread",
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {
@@ -156,9 +156,9 @@ func TestRouter_getUnreadItemsCount(t *testing.T) {
 			},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			ExpectedStatus: http.StatusInternalServerError,
-			ExpectedBody:   `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`,
+			ExpectedBody:   respInternalUnread,
 			Method:         http.MethodGet,
 			Target:         "/items/unread/count",
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {
@@ -191,9 +191,9 @@ func TestRouter_getStarredItemsCount(t *testing.T) {
 			},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			ExpectedStatus: http.StatusInternalServerError,
-			ExpectedBody:   `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`,
+			ExpectedBody:   respInternalUnread,
 			Method:         http.MethodGet,
 			Target:         "/items/starred/count",
 			MockFn: func(i *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {

--- a/internal/infra/http/api/login.go
+++ b/internal/infra/http/api/login.go
@@ -33,5 +33,6 @@ func (h *Router) login(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(response)
+	// AccessToken is a freshly minted JWT we are issuing to the caller, not a leaked secret.
+	_ = json.NewEncoder(w).Encode(response) //nolint:gosec // G117: intended response payload
 }

--- a/internal/infra/http/api/router_test.go
+++ b/internal/infra/http/api/router_test.go
@@ -38,7 +38,7 @@ func (s *spec) execHTTPTestCases(i *mocks.ItemService, f *mocks.FeedService, a *
 func (s *spec) HandlerTest(t *testing.T, h *api.Router) {
 	t.Helper()
 
-	req := httptest.NewRequest(s.Method, s.Target, strings.NewReader(s.ReqBody))
+	req := httptest.NewRequestWithContext(t.Context(), s.Method, s.Target, strings.NewReader(s.ReqBody))
 	if s.AuthToken != "" {
 		req.Header.Set("Authorization", "Bearer "+s.AuthToken)
 	}

--- a/internal/infra/http/api/signup_test.go
+++ b/internal/infra/http/api/signup_test.go
@@ -18,9 +18,9 @@ func TestRouter_signup(t *testing.T) {
 
 	specs := []spec{
 		{
-			Name:           "ok",
+			Name:           tcOK,
 			Method:         http.MethodPost,
-			Target:         "/signup",
+			Target:         signupPath,
 			ReqBody:        `{"email":"test@example.com","password":"password123"}`,
 			ExpectedStatus: http.StatusCreated,
 			ExpectedBody:   ``,
@@ -31,25 +31,25 @@ func TestRouter_signup(t *testing.T) {
 		{
 			Name:           "invalid json payload",
 			Method:         http.MethodPost,
-			Target:         "/signup",
+			Target:         signupPath,
 			ReqBody:        `{"email":"test@example.com","password":"password123"`,
 			ExpectedStatus: http.StatusBadRequest,
-			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - invalid request body"}}`,
+			ExpectedBody:   respInvalidReqBody,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
 			Name:           "missing required fields",
 			Method:         http.MethodPost,
-			Target:         "/signup",
+			Target:         signupPath,
 			ReqBody:        `{"email":"","password":""}`,
 			ExpectedStatus: http.StatusBadRequest,
-			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - invalid request body"}}`,
+			ExpectedBody:   respInvalidReqBody,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 		{
-			Name:           "service returns error",
+			Name:           tcServiceErr,
 			Method:         http.MethodPost,
-			Target:         "/signup",
+			Target:         signupPath,
 			ReqBody:        `{"email":"test@example.com","password":"password123"}`,
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - user already exists"}}`,
@@ -60,10 +60,10 @@ func TestRouter_signup(t *testing.T) {
 		{
 			Name:           "empty body",
 			Method:         http.MethodPost,
-			Target:         "/signup",
+			Target:         signupPath,
 			ReqBody:        ``,
 			ExpectedStatus: http.StatusBadRequest,
-			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - invalid request body"}}`,
+			ExpectedBody:   respInvalidReqBody,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
 		},
 	}

--- a/internal/infra/http/api/test_consts_test.go
+++ b/internal/infra/http/api/test_consts_test.go
@@ -1,0 +1,22 @@
+package api_test
+
+const (
+	tcOK            = "ok"
+	tcServiceErr    = "service returns error"
+	tcInvalidFeedID = "invalid feed id"
+
+	feedsPath     = "/feeds"
+	feed1Path     = "/feeds/1"
+	feedFetchPath = "/feeds/1/fetch"
+	item1Path     = "/items/1"
+	signupPath    = "/signup"
+
+	feedTitle = "title"
+	feedDesc  = "description"
+	feedLink  = "link"
+	feedDir   = "dir"
+
+	respInvalidFeedID  = `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`
+	respInternalUnread = `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`
+	respInvalidReqBody = `{"error":{"code":400,"details":"Bad Request - invalid request body"}}`
+)

--- a/internal/infra/sqlite/auth/auth.go
+++ b/internal/infra/sqlite/auth/auth.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
@@ -29,7 +31,9 @@ func NewDB(client *sql.DB) *DB {
 
 func (d *DB) GetUserByEmail(email string) (*auth.User, error) {
 	var user auth.User
-	err := d.sqliteDB.QueryRow("SELECT id, email, password FROM users WHERE email = ?", email).Scan(&user.ID, &user.Email, &user.Password)
+	err := d.sqliteDB.
+		QueryRowContext(context.Background(), "SELECT id, email, password FROM users WHERE email = ?", email).
+		Scan(&user.ID, &user.Email, &user.Password)
 	if err != nil {
 		return nil, err
 	}
@@ -37,12 +41,12 @@ func (d *DB) GetUserByEmail(email string) (*auth.User, error) {
 }
 
 func (d *DB) CreateUser(email, password string) error {
-	_, err := d.sqliteDB.Exec("INSERT INTO users (email, password) VALUES (?, ?)", email, password)
+	_, err := d.sqliteDB.ExecContext(context.Background(), "INSERT INTO users (email, password) VALUES (?, ?)", email, password)
 	return err
 }
 
 func (d *DB) GetAllUsers() ([]*auth.User, error) {
-	rows, err := d.sqliteDB.Query("SELECT id, email, password FROM users")
+	rows, err := d.sqliteDB.QueryContext(context.Background(), "SELECT id, email, password FROM users")
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +97,7 @@ func (d *DB) CreateSession(userID int) (*auth.Session, error) {
 	}
 
 	// Store session in database
-	_, err := d.sqliteDB.Exec(`
+	_, err := d.sqliteDB.ExecContext(context.Background(), `
         INSERT INTO sessions (id, user_id, access_token, refresh_token, expires_at, created_at)
         VALUES (?, ?, ?, ?, ?, ?)
     `, session.ID, session.UserID, session.AccessToken, session.RefreshToken, session.ExpiresAt, session.CreatedAt)
@@ -107,7 +111,7 @@ func (d *DB) CreateSession(userID int) (*auth.Session, error) {
 
 func (d *DB) GetSessionByToken(token string) (*auth.Session, error) {
 	var session auth.Session
-	err := d.sqliteDB.QueryRow(`
+	err := d.sqliteDB.QueryRowContext(context.Background(), `
 	    SELECT id, user_id, access_token, refresh_token, expires_at, created_at 
 	    FROM sessions 
 	    WHERE access_token = ?`, token).Scan(

--- a/internal/infra/sqlite/feed/feed.go
+++ b/internal/infra/sqlite/feed/feed.go
@@ -1,6 +1,8 @@
 package feed
 
 import (
+	"context"
+
 	"database/sql"
 	"time"
 
@@ -18,7 +20,8 @@ func NewDB(client *sql.DB) *DB {
 }
 
 func (r *DB) AddFeed(f *feed.Feed) (int, error) {
-	result, err := r.sqliteDB.Exec("INSERT INTO rss (title, desc, link, url, lang, user_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	const q = "INSERT INTO rss (title, desc, link, url, lang, user_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+	result, err := r.sqliteDB.ExecContext(context.Background(), q,
 		f.Title, f.Description, f.Link, f.URL, f.Lang, f.UserID, f.UpdatedAt.Format(time.RFC3339))
 	if err != nil {
 		return 0, err
@@ -34,7 +37,7 @@ func (r *DB) GetFeed(id int) (*feed.Feed, error) {
 	query := "SELECT " +
 		"id, title, desc, link, url, lang, updated_at, " +
 		"(SELECT COUNT(*) FROM item WHERE rss_id = rss.id AND is_new = 1) AS unread_count FROM rss where id = ?"
-	rows, err := r.sqliteDB.Query(query, id)
+	rows, err := r.sqliteDB.QueryContext(context.Background(), query, id)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +57,7 @@ func (r *DB) ListFeeds(userID int) ([]*feed.Feed, error) {
 		"id, title, desc, link, url, lang, updated_at, " +
 		"(SELECT COUNT(*) FROM item WHERE rss_id = rss.id AND is_new = 1) AS unread_count FROM rss " +
 		"WHERE user_id = ?"
-	rows, err := r.sqliteDB.Query(query, userID)
+	rows, err := r.sqliteDB.QueryContext(context.Background(), query, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +70,7 @@ func (r *DB) ListFeeds(userID int) ([]*feed.Feed, error) {
 }
 
 func (r *DB) DeleteFeed(id int) error {
-	_, err := r.sqliteDB.Exec("DELETE FROM rss WHERE id = ?", id)
+	_, err := r.sqliteDB.ExecContext(context.Background(), "DELETE FROM rss WHERE id = ?", id)
 	return err
 }
 

--- a/internal/infra/sqlite/item/item.go
+++ b/internal/infra/sqlite/item/item.go
@@ -1,6 +1,8 @@
 package item
 
 import (
+	"context"
+
 	"database/sql"
 	"time"
 
@@ -19,7 +21,7 @@ func NewDB(client *sql.DB) *DB {
 
 func (r *DB) GetUnreadItems() ([]*item.Item, error) {
 	query := "SELECT id, is_new, desc, link, rss_id, title, dir, starred, timestamp FROM item WHERE is_new = 1 ORDER BY timestamp DESC"
-	result, err := r.sqliteDB.Query(query)
+	result, err := r.sqliteDB.QueryContext(context.Background(), query)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +30,7 @@ func (r *DB) GetUnreadItems() ([]*item.Item, error) {
 
 func (r *DB) GetStarredItems() ([]*item.Item, error) {
 	query := "SELECT id, is_new, desc, link, rss_id, title, dir, starred, timestamp FROM item WHERE starred = 1 ORDER BY timestamp DESC"
-	result, err := r.sqliteDB.Query(query)
+	result, err := r.sqliteDB.QueryContext(context.Background(), query)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +39,7 @@ func (r *DB) GetStarredItems() ([]*item.Item, error) {
 
 func (r *DB) GetFeedItems(feedID int) ([]*item.Item, error) {
 	query := "SELECT id, is_new, desc, link, rss_id, title, dir, starred, timestamp FROM item WHERE rss_id = ? ORDER BY timestamp DESC"
-	result, err := r.sqliteDB.Query(query, feedID)
+	result, err := r.sqliteDB.QueryContext(context.Background(), query, feedID)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +99,7 @@ func (r *DB) UpsertItems(feedID int, items []*item.Item) error {
 
 func (r *DB) UpsertItem(feedID int, i *item.Item) (int, error) {
 	// first find if item exists
-	result, err := r.sqliteDB.Query("SELECT id FROM item WHERE link = ? AND rss_id = ?", i.Link, feedID)
+	result, err := r.sqliteDB.QueryContext(context.Background(), "SELECT id FROM item WHERE link = ? AND rss_id = ?", i.Link, feedID)
 	if err != nil {
 		return 0, err
 	}
@@ -117,7 +119,7 @@ func (r *DB) UpsertItem(feedID int, i *item.Item) (int, error) {
 	}
 	// if item does not exist, insert it
 	query := "INSERT INTO item (is_new, desc, link, rss_id, title, dir, timestamp) VALUES (?, ?, ?, ?, ?, ?, ?)"
-	insertResult, execErr := r.sqliteDB.Exec(query, i.IsNew, i.Desc, i.Link, feedID, i.Title, i.Dir, i.Timestamp)
+	insertResult, execErr := r.sqliteDB.ExecContext(context.Background(), query, i.IsNew, i.Desc, i.Link, feedID, i.Title, i.Dir, i.Timestamp)
 	if execErr != nil {
 		return 0, execErr
 	}
@@ -129,7 +131,7 @@ func (r *DB) UpsertItem(feedID int, i *item.Item) (int, error) {
 }
 
 func (r *DB) UpdateItem(id int, starred, isNew bool) error {
-	_, err := r.sqliteDB.Exec("UPDATE item SET starred = ?, is_new = ? WHERE id = ?", starred, isNew, id)
+	_, err := r.sqliteDB.ExecContext(context.Background(), "UPDATE item SET starred = ?, is_new = ? WHERE id = ?", starred, isNew, id)
 	if err != nil {
 		return err
 	}
@@ -137,7 +139,7 @@ func (r *DB) UpdateItem(id int, starred, isNew bool) error {
 }
 
 func (r *DB) ReadFeedItems(feedID int) error {
-	_, err := r.sqliteDB.Exec("UPDATE item SET is_new = 0 WHERE rss_id = ?", feedID)
+	_, err := r.sqliteDB.ExecContext(context.Background(), "UPDATE item SET is_new = 0 WHERE rss_id = ?", feedID)
 	if err != nil {
 		return err
 	}
@@ -145,7 +147,7 @@ func (r *DB) ReadFeedItems(feedID int) error {
 }
 
 func (r *DB) UnreadFeedItems(feedID int) error {
-	_, err := r.sqliteDB.Exec("UPDATE item SET is_new = 1 WHERE rss_id = ?", feedID)
+	_, err := r.sqliteDB.ExecContext(context.Background(), "UPDATE item SET is_new = 1 WHERE rss_id = ?", feedID)
 	if err != nil {
 		return err
 	}
@@ -153,7 +155,7 @@ func (r *DB) UnreadFeedItems(feedID int) error {
 }
 
 func (r *DB) GetUnreadItemsCount() (int, error) {
-	result, err := r.sqliteDB.Query("SELECT COUNT(*) FROM item WHERE is_new = 1")
+	result, err := r.sqliteDB.QueryContext(context.Background(), "SELECT COUNT(*) FROM item WHERE is_new = 1")
 	if err != nil {
 		return 0, err
 	}
@@ -171,7 +173,7 @@ func (r *DB) GetUnreadItemsCount() (int, error) {
 }
 
 func (r *DB) GetStarredItemsCount() (int, error) {
-	result, err := r.sqliteDB.Query("SELECT COUNT(*) FROM item WHERE starred = 1")
+	result, err := r.sqliteDB.QueryContext(context.Background(), "SELECT COUNT(*) FROM item WHERE starred = 1")
 	if err != nil {
 		return 0, err
 	}
@@ -189,6 +191,6 @@ func (r *DB) GetStarredItemsCount() (int, error) {
 }
 
 func (r *DB) DeleteFeedItems(feedID int) error {
-	_, err := r.sqliteDB.Exec("DELETE FROM item WHERE rss_id = ?", feedID)
+	_, err := r.sqliteDB.ExecContext(context.Background(), "DELETE FROM item WHERE rss_id = ?", feedID)
 	return err
 }

--- a/internal/testserver/feedserver.go
+++ b/internal/testserver/feedserver.go
@@ -94,5 +94,6 @@ func (m *MockFeedServer) serveFeed(w http.ResponseWriter, r *http.Request) {
 	// Set appropriate content type
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(content)
+	// content is a fixed RSS/Atom XML fixture loaded from the testserver fixtures directory.
+	_, _ = w.Write(content) //nolint:gosec // G705: test-only mock feed server
 }


### PR DESCRIPTION
## Summary
Follow-up to #37. Removes the path-scoped lint exclusions and fixes the 57 underlying findings that the v1→v2 golangci-lint upgrade surfaced (CI saw 45 due to `max-same-issues=3` default; uncapped count is 57).

- **goconst×34** — Extract repeated test fixtures (`"success"`, `"test@example.com"`, `"/feeds"`, error JSON payloads, etc.) to package-level constants. Adds a shared `test_consts_test.go` for the `api_test` package.
- **noctx×21** — Switch sqlite repos (auth, feed, item) to `*Context` variants using `context.Background()` at the boundary. `router_test` uses `httptest.NewRequestWithContext(t.Context(), …)`. Plumbing a real `context.Context` through the `Repository` / `Service` interfaces is left for a separate, focused refactor.
- **gosec×2** — Justified `//nolint:gosec` on the JWT-bearing login response (G117) and the test-only mock RSS write (G705).

The temporary path-scoped exclusions added in PR #37 (`goconst` on `_test.go`, `noctx` on sqlite, `gosec` on login/testserver) are removed.

## Test plan
- [x] `go test -mod=vendor -race ./...` — all packages pass
- [x] `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` → `0 issues`
- [x] `make build` produces a static binary
- [ ] CI green (`tests.yaml` + `pr.yml` linter job + matrix tests)

## Out of scope
- End-to-end `context.Context` propagation through `Repository` / `Service` interfaces (would touch ~15 files including mocks). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)