### PR TITLE
Add setup wizard for first user and admin-controlled signup toggle

### DIFF
--- a/internal/app/auth/command.go
+++ b/internal/app/auth/command.go
@@ -24,7 +24,28 @@ type SignupCommand struct {
 	ConfirmPassword string `json:"confirm_password"`
 }
 
+// SetupCommand is used for the initial admin setup wizard.
+type SetupCommand struct {
+	Email           string `json:"email"`
+	Password        string `json:"password"`
+	ConfirmPassword string `json:"confirm_password"`
+	AllowSignup     bool   `json:"allow_signup"`
+}
+
 func (c *SignupCommand) Validate() error {
+	if c.Email == "" || c.Password == "" || c.ConfirmPassword == "" {
+		return errors.New("email and password are required")
+	}
+	if c.Password != c.ConfirmPassword {
+		return errors.New("password and confirm password do not match")
+	}
+	if len(c.Password) < minPasswordLength {
+		return errors.New("password must be at least 8 characters")
+	}
+	return nil
+}
+
+func (c *SetupCommand) Validate() error {
 	if c.Email == "" || c.Password == "" || c.ConfirmPassword == "" {
 		return errors.New("email and password are required")
 	}

--- a/internal/app/auth/dependencies.go
+++ b/internal/app/auth/dependencies.go
@@ -3,7 +3,11 @@ package auth
 type Repository interface {
 	GetUserByEmail(email string) (*User, error)
 	CreateUser(email, password string) error
+	CreateAdmin(email, password string) error
 	CreateSession(userID int) (*Session, error)
 	GetSessionByToken(token string) (*Session, error)
 	GetAllUsers() ([]*User, error)
+	CountUsers() (int, error)
+	GetSetting(key string) (string, error)
+	SetSetting(key, value string) error
 }

--- a/internal/app/auth/domain.go
+++ b/internal/app/auth/domain.go
@@ -6,6 +6,7 @@ type User struct {
 	ID       int    `json:"id"`
 	Email    string `json:"email"`
 	Password string `json:"-"` // bcrypt hashed
+	IsAdmin  bool   `json:"is_admin"`
 }
 
 type Login struct {

--- a/internal/app/auth/service.go
+++ b/internal/app/auth/service.go
@@ -9,7 +9,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const settingAllowSignup = "allow_signup"
+const (
+	settingAllowSignup = "allow_signup"
+	valTrue            = "true"
+	valFalse           = "false"
+)
 
 type Service struct {
 	repo Repository
@@ -93,9 +97,9 @@ func (s *Service) Setup(command *SetupCommand) error {
 		return err
 	}
 
-	allowSignup := "false"
+	allowSignup := valFalse
 	if command.AllowSignup {
-		allowSignup = "true"
+		allowSignup = valTrue
 	}
 
 	return s.repo.SetSetting(settingAllowSignup, allowSignup)
@@ -116,14 +120,14 @@ func (s *Service) IsSignupAllowed() bool {
 	if err != nil {
 		return false
 	}
-	return val == "true"
+	return val == valTrue
 }
 
 // SetAllowSignup toggles the allow_signup setting.
 func (s *Service) SetAllowSignup(allow bool) error {
-	val := "false"
+	val := valFalse
 	if allow {
-		val = "true"
+		val = valTrue
 	}
 	return s.repo.SetSetting(settingAllowSignup, val)
 }

--- a/internal/app/auth/service.go
+++ b/internal/app/auth/service.go
@@ -2,11 +2,14 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
 )
+
+const settingAllowSignup = "allow_signup"
 
 type Service struct {
 	repo Repository
@@ -41,6 +44,11 @@ func (s *Service) Login(command *LoginCommand) (*LoginResponse, error) {
 }
 
 func (s *Service) Signup(command *SignupCommand) error {
+	// Check if signup is allowed
+	if !s.IsSignupAllowed() {
+		return errors.New("registration is currently disabled")
+	}
+
 	// Check if user already exists
 	_, err := s.repo.GetUserByEmail(command.Email)
 	if err == nil {
@@ -62,6 +70,62 @@ func (s *Service) Signup(command *SignupCommand) error {
 	default:
 		return err
 	}
+}
+
+// Setup creates the first admin user. It only works when there are zero users
+// in the database.
+func (s *Service) Setup(command *SetupCommand) error {
+	count, err := s.repo.CountUsers()
+	if err != nil {
+		return fmt.Errorf("failed to check user count: %w", err)
+	}
+
+	if count > 0 {
+		return errors.New("setup has already been completed")
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(command.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	if err := s.repo.CreateAdmin(command.Email, string(hashedPassword)); err != nil {
+		return err
+	}
+
+	allowSignup := "false"
+	if command.AllowSignup {
+		allowSignup = "true"
+	}
+
+	return s.repo.SetSetting(settingAllowSignup, allowSignup)
+}
+
+// NeedsSetup returns true if no users exist yet (first-run state).
+func (s *Service) NeedsSetup() (bool, error) {
+	count, err := s.repo.CountUsers()
+	if err != nil {
+		return false, err
+	}
+	return count == 0, nil
+}
+
+// IsSignupAllowed checks the allow_signup setting. Defaults to false on error.
+func (s *Service) IsSignupAllowed() bool {
+	val, err := s.repo.GetSetting(settingAllowSignup)
+	if err != nil {
+		return false
+	}
+	return val == "true"
+}
+
+// SetAllowSignup toggles the allow_signup setting.
+func (s *Service) SetAllowSignup(allow bool) error {
+	val := "false"
+	if allow {
+		val = "true"
+	}
+	return s.repo.SetSetting(settingAllowSignup, val)
 }
 
 func (s *Service) GetSession(token string) (*Session, error) {

--- a/internal/app/auth/service_test.go
+++ b/internal/app/auth/service_test.go
@@ -34,6 +34,7 @@ func TestService_Signup(t *testing.T) {
 				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("true", nil)
 				r.EXPECT().GetUserByEmail(testEmail).Return(nil, errors.New("not found"))
 				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(nil)
 			},
@@ -46,6 +47,7 @@ func TestService_Signup(t *testing.T) {
 				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("true", nil)
 				r.EXPECT().GetUserByEmail("existing@example.com").Return(&auth.User{}, nil)
 			},
 			wantErr: true,
@@ -58,6 +60,7 @@ func TestService_Signup(t *testing.T) {
 				Password: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("true", nil)
 				r.EXPECT().GetUserByEmail(testEmail).Return(nil, errors.New("not found"))
 				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(errors.New("db error"))
 			},
@@ -273,6 +276,318 @@ func TestService_GetAllUsers(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, got)
+			}
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestService_Setup(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   *auth.SetupCommand
+		mockSetup func(*mocks.Repository)
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "success - creates admin and sets allow_signup to false",
+			command: &auth.SetupCommand{
+				Email:           testEmail,
+				Password:        testPassword,
+				ConfirmPassword: testPassword,
+				AllowSignup:     false,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(0, nil)
+				r.EXPECT().CreateAdmin(testEmail, gomock.Any()).Return(nil)
+				r.EXPECT().SetSetting("allow_signup", "false").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "success - creates admin and sets allow_signup to true",
+			command: &auth.SetupCommand{
+				Email:           testEmail,
+				Password:        testPassword,
+				ConfirmPassword: testPassword,
+				AllowSignup:     true,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(0, nil)
+				r.EXPECT().CreateAdmin(testEmail, gomock.Any()).Return(nil)
+				r.EXPECT().SetSetting("allow_signup", "true").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "error - users already exist",
+			command: &auth.SetupCommand{
+				Email:           testEmail,
+				Password:        testPassword,
+				ConfirmPassword: testPassword,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(1, nil)
+			},
+			wantErr: true,
+			errMsg:  "setup has already been completed",
+		},
+		{
+			name: "error - count users fails",
+			command: &auth.SetupCommand{
+				Email:           testEmail,
+				Password:        testPassword,
+				ConfirmPassword: testPassword,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(0, errors.New("db error"))
+			},
+			wantErr: true,
+			errMsg:  "db error",
+		},
+		{
+			name: "error - create admin fails",
+			command: &auth.SetupCommand{
+				Email:           testEmail,
+				Password:        testPassword,
+				ConfirmPassword: testPassword,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(0, nil)
+				r.EXPECT().CreateAdmin(testEmail, gomock.Any()).Return(errors.New("db error"))
+			},
+			wantErr: true,
+			errMsg:  "db error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			repo := mocks.NewRepository(ctrl)
+			tt.mockSetup(repo)
+
+			s := auth.NewService(repo)
+			err := s.Setup(tt.command)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestService_NeedsSetup(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockSetup func(*mocks.Repository)
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "needs setup - zero users",
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(0, nil)
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "does not need setup - users exist",
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(1, nil)
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "error counting users",
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().CountUsers().Return(0, errors.New("db error"))
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			repo := mocks.NewRepository(ctrl)
+			tt.mockSetup(repo)
+
+			s := auth.NewService(repo)
+			got, err := s.NeedsSetup()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestService_IsSignupAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockSetup func(*mocks.Repository)
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "signup allowed",
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("true", nil)
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "signup not allowed",
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("false", nil)
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "error getting setting - defaults to false",
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("", errors.New("not found"))
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			repo := mocks.NewRepository(ctrl)
+			tt.mockSetup(repo)
+
+			s := auth.NewService(repo)
+			got := s.IsSignupAllowed()
+
+			assert.Equal(t, tt.want, got)
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestService_SetAllowSignup(t *testing.T) {
+	tests := []struct {
+		name      string
+		allow     bool
+		mockSetup func(*mocks.Repository)
+		wantErr   bool
+	}{
+		{
+			name:  "set allow signup to true",
+			allow: true,
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().SetSetting("allow_signup", "true").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "set allow signup to false",
+			allow: false,
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().SetSetting("allow_signup", "false").Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "error setting",
+			allow: true,
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().SetSetting("allow_signup", "true").Return(errors.New("db error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			repo := mocks.NewRepository(ctrl)
+			tt.mockSetup(repo)
+
+			s := auth.NewService(repo)
+			err := s.SetAllowSignup(tt.allow)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			ctrl.Finish()
+		})
+	}
+}
+
+func TestService_Signup_GuardedByAllowSignup(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   *auth.SignupCommand
+		mockSetup func(*mocks.Repository)
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "signup allowed",
+			command: &auth.SignupCommand{
+				Email:    testEmail,
+				Password: testPassword,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("true", nil)
+				r.EXPECT().GetUserByEmail(testEmail).Return(nil, errors.New("not found"))
+				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "signup not allowed",
+			command: &auth.SignupCommand{
+				Email:    testEmail,
+				Password: testPassword,
+			},
+			mockSetup: func(r *mocks.Repository) {
+				r.EXPECT().GetSetting("allow_signup").Return("false", nil)
+			},
+			wantErr: true,
+			errMsg:  "registration is currently disabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			repo := mocks.NewRepository(ctrl)
+			tt.mockSetup(repo)
+
+			s := auth.NewService(repo)
+			err := s.Signup(tt.command)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
 			}
 			ctrl.Finish()
 		})

--- a/internal/app/auth/service_test.go
+++ b/internal/app/auth/service_test.go
@@ -17,6 +17,7 @@ const (
 	tcSuccess    = "success"
 	testEmail    = "test@example.com"
 	testPassword = "password123"
+	errDBError   = "db error"
 )
 
 func TestService_Signup(t *testing.T) {
@@ -62,10 +63,10 @@ func TestService_Signup(t *testing.T) {
 			mockSetup: func(r *mocks.Repository) {
 				r.EXPECT().GetSetting("allow_signup").Return("true", nil)
 				r.EXPECT().GetUserByEmail(testEmail).Return(nil, errors.New("not found"))
-				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(errors.New("db error"))
+				r.EXPECT().CreateUser(testEmail, gomock.Any()).Return(errors.New(errDBError))
 			},
 			wantErr: true,
-			errMsg:  "db error",
+			errMsg:  errDBError,
 		},
 	}
 
@@ -256,7 +257,7 @@ func TestService_GetAllUsers(t *testing.T) {
 		{
 			name: "error",
 			mockSetup: func(r *mocks.Repository) {
-				r.EXPECT().GetAllUsers().Return(nil, errors.New("db error"))
+				r.EXPECT().GetAllUsers().Return(nil, errors.New(errDBError))
 			},
 			wantErr: true,
 		},
@@ -341,10 +342,10 @@ func TestService_Setup(t *testing.T) {
 				ConfirmPassword: testPassword,
 			},
 			mockSetup: func(r *mocks.Repository) {
-				r.EXPECT().CountUsers().Return(0, errors.New("db error"))
+				r.EXPECT().CountUsers().Return(0, errors.New(errDBError))
 			},
 			wantErr: true,
-			errMsg:  "db error",
+			errMsg:  errDBError,
 		},
 		{
 			name: "error - create admin fails",
@@ -355,10 +356,10 @@ func TestService_Setup(t *testing.T) {
 			},
 			mockSetup: func(r *mocks.Repository) {
 				r.EXPECT().CountUsers().Return(0, nil)
-				r.EXPECT().CreateAdmin(testEmail, gomock.Any()).Return(errors.New("db error"))
+				r.EXPECT().CreateAdmin(testEmail, gomock.Any()).Return(errors.New(errDBError))
 			},
 			wantErr: true,
-			errMsg:  "db error",
+			errMsg:  errDBError,
 		},
 	}
 
@@ -410,7 +411,7 @@ func TestService_NeedsSetup(t *testing.T) {
 		{
 			name: "error counting users",
 			mockSetup: func(r *mocks.Repository) {
-				r.EXPECT().CountUsers().Return(0, errors.New("db error"))
+				r.EXPECT().CountUsers().Return(0, errors.New(errDBError))
 			},
 			want:    false,
 			wantErr: true,
@@ -512,7 +513,7 @@ func TestService_SetAllowSignup(t *testing.T) {
 			name:  "error setting",
 			allow: true,
 			mockSetup: func(r *mocks.Repository) {
-				r.EXPECT().SetSetting("allow_signup", "true").Return(errors.New("db error"))
+				r.EXPECT().SetSetting("allow_signup", "true").Return(errors.New(errDBError))
 			},
 			wantErr: true,
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,11 +19,6 @@ type HTTP struct {
 	Port int `env:"HTTP_PORT, default=3000"`
 }
 
-type Auth struct {
-	Email    string `env:"AUTH_EMAIL"`
-	Password string `env:"AUTH_PASSWORD"`
-}
-
 // New constructs the config.
 // variables are populated using the envars and default values.
 func New(ctx context.Context) (*Config, error) {

--- a/internal/infra/http/api/middleware/middleware.go
+++ b/internal/infra/http/api/middleware/middleware.go
@@ -62,8 +62,8 @@ func AuthMiddleware(authService AuthService) HandleFunc {
 			w.Header().Set("Content-Type", "application/json")
 			log.Printf("Request path: %s", r.URL.Path)
 
-			// Skip auth check for login and signup endpoints
-			if r.URL.Path == "/login" || r.URL.Path == "/signup" {
+			// Skip auth check for login, signup, and setup endpoints
+			if r.URL.Path == "/login" || r.URL.Path == "/signup" || r.URL.Path == "/setup" || r.URL.Path == "/setup/status" {
 				next(w, r, ps)
 				return
 			}

--- a/internal/infra/http/api/router.go
+++ b/internal/infra/http/api/router.go
@@ -53,6 +53,10 @@ type ItemService interface {
 type AuthService interface {
 	Login(command *auth.LoginCommand) (*auth.LoginResponse, error)
 	Signup(command *auth.SignupCommand) error
+	Setup(command *auth.SetupCommand) error
+	NeedsSetup() (bool, error)
+	IsSignupAllowed() bool
+	SetAllowSignup(allow bool) error
 	GetSession(token string) (*auth.Session, error)
 	GetAllUsers() ([]*auth.User, error)
 }
@@ -99,6 +103,11 @@ func New(itemService ItemService, feedService FeedService, authService AuthServi
 
 	router.POST("/login", chain.Wrap(h.login))
 	router.POST("/signup", chain.Wrap(h.signup))
+	router.POST("/setup", chain.Wrap(h.setup))
+	router.GET("/setup/status", chain.Wrap(h.needsSetup))
+
+	router.GET("/settings", chain.Wrap(h.getSettings))
+	router.PUT("/settings", chain.Wrap(h.updateSettings))
 	// Serve static frontend assets via NotFound. Restrict to GET/HEAD so a
 	// stray POST/PUT/DELETE to an unknown path returns 404 instead of the
 	// 405 that http.FileServer would emit, which would mask missing API

--- a/internal/infra/http/api/setup.go
+++ b/internal/infra/http/api/setup.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/cubny/lite-reader/internal/app/auth"
+)
+
+func (h *Router) setup(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var command auth.SetupCommand
+	if err := json.NewDecoder(r.Body).Decode(&command); err != nil {
+		log.WithError(err).Error("setup: failed to decode request body")
+		_ = BadRequest(w, "invalid request body")
+		return
+	}
+
+	if err := command.Validate(); err != nil {
+		_ = BadRequest(w, err.Error())
+		return
+	}
+
+	if err := h.authService.Setup(&command); err != nil {
+		_ = BadRequest(w, err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *Router) needsSetup(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	needs, err := h.authService.NeedsSetup()
+	if err != nil {
+		_ = InternalError(w, "failed to check setup status")
+		return
+	}
+
+	allowSignup := h.authService.IsSignupAllowed()
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"needs_setup":  needs,
+		"allow_signup": allowSignup,
+	})
+}
+
+func (h *Router) getSettings(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	allowSignup := h.authService.IsSignupAllowed()
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]bool{"allow_signup": allowSignup})
+}
+
+func (h *Router) updateSettings(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	var req struct {
+		AllowSignup bool `json:"allow_signup"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_ = BadRequest(w, "invalid request body")
+		return
+	}
+
+	if err := h.authService.SetAllowSignup(req.AllowSignup); err != nil {
+		_ = InternalError(w, "failed to update settings")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]bool{"allow_signup": req.AllowSignup})
+}

--- a/internal/infra/http/api/setup.go
+++ b/internal/infra/http/api/setup.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cubny/lite-reader/internal/app/auth"
 )
 
+const keyAllowSignup = "allow_signup"
+
 func (h *Router) setup(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var command auth.SetupCommand
 	if err := json.NewDecoder(r.Body).Decode(&command); err != nil {
@@ -43,7 +45,7 @@ func (h *Router) needsSetup(w http.ResponseWriter, _ *http.Request, _ httprouter
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"needs_setup":  needs,
-		"allow_signup": allowSignup,
+		keyAllowSignup: allowSignup,
 	})
 }
 
@@ -51,7 +53,7 @@ func (h *Router) getSettings(w http.ResponseWriter, _ *http.Request, _ httproute
 	allowSignup := h.authService.IsSignupAllowed()
 
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]bool{"allow_signup": allowSignup})
+	_ = json.NewEncoder(w).Encode(map[string]bool{keyAllowSignup: allowSignup})
 }
 
 func (h *Router) updateSettings(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -69,5 +71,5 @@ func (h *Router) updateSettings(w http.ResponseWriter, r *http.Request, _ httpro
 	}
 
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]bool{"allow_signup": req.AllowSignup})
+	_ = json.NewEncoder(w).Encode(map[string]bool{keyAllowSignup: req.AllowSignup})
 }

--- a/internal/infra/http/api/setup_test.go
+++ b/internal/infra/http/api/setup_test.go
@@ -1,0 +1,204 @@
+package api_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/cubny/lite-reader/internal/app/auth"
+	mocks "github.com/cubny/lite-reader/internal/mocks/infra/http/api"
+)
+
+func testSession() *auth.Session {
+	return &auth.Session{
+		ID:           "test-session",
+		UserID:       1,
+		AccessToken:  "test",
+		RefreshToken: "test-refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		CreatedAt:    time.Now(),
+	}
+}
+
+func TestRouter_setup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	feedService := mocks.NewFeedService(ctrl)
+	itemService := mocks.NewItemService(ctrl)
+	authService := mocks.NewAuthService(ctrl)
+
+	specs := []spec{
+		{
+			Name:           tcOK,
+			Method:         http.MethodPost,
+			Target:         "/setup",
+			ReqBody:        `{"email":"admin@example.com","password":"password123","confirm_password":"password123","allow_signup":false}`,
+			ExpectedStatus: http.StatusCreated,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().Setup(gomock.Any()).Return(nil)
+			},
+		},
+		{
+			Name:           "setup already completed",
+			Method:         http.MethodPost,
+			Target:         "/setup",
+			ReqBody:        `{"email":"admin@example.com","password":"password123","confirm_password":"password123"}`,
+			ExpectedStatus: http.StatusBadRequest,
+			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - setup has already been completed"}}`,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().Setup(gomock.Any()).Return(errors.New("setup has already been completed"))
+			},
+		},
+		{
+			Name:           "invalid json",
+			Method:         http.MethodPost,
+			Target:         "/setup",
+			ReqBody:        `{invalid`,
+			ExpectedStatus: http.StatusBadRequest,
+			ExpectedBody:   respInvalidReqBody,
+			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
+		},
+		{
+			Name:           "validation error - passwords don't match",
+			Method:         http.MethodPost,
+			Target:         "/setup",
+			ReqBody:        `{"email":"admin@example.com","password":"password123","confirm_password":"different"}`,
+			ExpectedStatus: http.StatusBadRequest,
+			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - password and confirm password do not match"}}`,
+			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
+		},
+		{
+			Name:           "validation error - missing fields",
+			Method:         http.MethodPost,
+			Target:         "/setup",
+			ReqBody:        `{"email":"","password":"","confirm_password":""}`,
+			ExpectedStatus: http.StatusBadRequest,
+			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.Name, s.execHTTPTestCases(itemService, feedService, authService))
+	}
+}
+
+func TestRouter_needsSetup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	feedService := mocks.NewFeedService(ctrl)
+	itemService := mocks.NewItemService(ctrl)
+	authService := mocks.NewAuthService(ctrl)
+
+	specs := []spec{
+		{
+			Name:           "needs setup",
+			Method:         http.MethodGet,
+			Target:         "/setup/status",
+			ExpectedStatus: http.StatusOK,
+			ExpectedBody:   `{"needs_setup":true,"allow_signup":false}`,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().NeedsSetup().Return(true, nil)
+				a.EXPECT().IsSignupAllowed().Return(false)
+			},
+		},
+		{
+			Name:           "setup already done",
+			Method:         http.MethodGet,
+			Target:         "/setup/status",
+			ExpectedStatus: http.StatusOK,
+			ExpectedBody:   `{"needs_setup":false,"allow_signup":true}`,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().NeedsSetup().Return(false, nil)
+				a.EXPECT().IsSignupAllowed().Return(true)
+			},
+		},
+		{
+			Name:           "error checking setup",
+			Method:         http.MethodGet,
+			Target:         "/setup/status",
+			ExpectedStatus: http.StatusInternalServerError,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().NeedsSetup().Return(false, errors.New("db error"))
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.Name, s.execHTTPTestCases(itemService, feedService, authService))
+	}
+}
+
+func TestRouter_getSettings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	feedService := mocks.NewFeedService(ctrl)
+	itemService := mocks.NewItemService(ctrl)
+	authService := mocks.NewAuthService(ctrl)
+
+	specs := []spec{
+		{
+			Name:           "get settings",
+			Method:         http.MethodGet,
+			Target:         "/settings",
+			ExpectedStatus: http.StatusOK,
+			ExpectedBody:   `{"allow_signup":true}`,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().GetSession("test").Return(testSession(), nil)
+				a.EXPECT().IsSignupAllowed().Return(true)
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.Name, s.execHTTPTestCases(itemService, feedService, authService))
+	}
+}
+
+func TestRouter_updateSettings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	feedService := mocks.NewFeedService(ctrl)
+	itemService := mocks.NewItemService(ctrl)
+	authService := mocks.NewAuthService(ctrl)
+
+	specs := []spec{
+		{
+			Name:           "update settings - allow signup",
+			Method:         http.MethodPut,
+			Target:         "/settings",
+			ReqBody:        `{"allow_signup":true}`,
+			ExpectedStatus: http.StatusOK,
+			ExpectedBody:   `{"allow_signup":true}`,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().GetSession("test").Return(testSession(), nil)
+				a.EXPECT().SetAllowSignup(true).Return(nil)
+			},
+		},
+		{
+			Name:           "update settings - disable signup",
+			Method:         http.MethodPut,
+			Target:         "/settings",
+			ReqBody:        `{"allow_signup":false}`,
+			ExpectedStatus: http.StatusOK,
+			ExpectedBody:   `{"allow_signup":false}`,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().GetSession("test").Return(testSession(), nil)
+				a.EXPECT().SetAllowSignup(false).Return(nil)
+			},
+		},
+		{
+			Name:           "update settings - error",
+			Method:         http.MethodPut,
+			Target:         "/settings",
+			ReqBody:        `{"allow_signup":true}`,
+			ExpectedStatus: http.StatusInternalServerError,
+			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
+				a.EXPECT().GetSession("test").Return(testSession(), nil)
+				a.EXPECT().SetAllowSignup(true).Return(errors.New("db error"))
+			},
+		},
+	}
+
+	for _, s := range specs {
+		t.Run(s.Name, s.execHTTPTestCases(itemService, feedService, authService))
+	}
+}

--- a/internal/infra/http/api/setup_test.go
+++ b/internal/infra/http/api/setup_test.go
@@ -33,7 +33,7 @@ func TestRouter_setup(t *testing.T) {
 		{
 			Name:           tcOK,
 			Method:         http.MethodPost,
-			Target:         "/setup",
+			Target:         setupPath,
 			ReqBody:        `{"email":"admin@example.com","password":"password123","confirm_password":"password123","allow_signup":false}`,
 			ExpectedStatus: http.StatusCreated,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
@@ -43,7 +43,7 @@ func TestRouter_setup(t *testing.T) {
 		{
 			Name:           "setup already completed",
 			Method:         http.MethodPost,
-			Target:         "/setup",
+			Target:         setupPath,
 			ReqBody:        `{"email":"admin@example.com","password":"password123","confirm_password":"password123"}`,
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - setup has already been completed"}}`,
@@ -54,7 +54,7 @@ func TestRouter_setup(t *testing.T) {
 		{
 			Name:           "invalid json",
 			Method:         http.MethodPost,
-			Target:         "/setup",
+			Target:         setupPath,
 			ReqBody:        `{invalid`,
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   respInvalidReqBody,
@@ -63,7 +63,7 @@ func TestRouter_setup(t *testing.T) {
 		{
 			Name:           "validation error - passwords don't match",
 			Method:         http.MethodPost,
-			Target:         "/setup",
+			Target:         setupPath,
 			ReqBody:        `{"email":"admin@example.com","password":"password123","confirm_password":"different"}`,
 			ExpectedStatus: http.StatusBadRequest,
 			ExpectedBody:   `{"error":{"code":400,"details":"Bad Request - password and confirm password do not match"}}`,
@@ -72,7 +72,7 @@ func TestRouter_setup(t *testing.T) {
 		{
 			Name:           "validation error - missing fields",
 			Method:         http.MethodPost,
-			Target:         "/setup",
+			Target:         setupPath,
 			ReqBody:        `{"email":"","password":"","confirm_password":""}`,
 			ExpectedStatus: http.StatusBadRequest,
 			MockFn:         func(_ *mocks.ItemService, _ *mocks.FeedService, _ *mocks.AuthService) {},
@@ -94,9 +94,9 @@ func TestRouter_needsSetup(t *testing.T) {
 		{
 			Name:           "needs setup",
 			Method:         http.MethodGet,
-			Target:         "/setup/status",
+			Target:         setupStatusPath,
 			ExpectedStatus: http.StatusOK,
-			ExpectedBody:   `{"needs_setup":true,"allow_signup":false}`,
+			ExpectedBody:   `{"allow_signup":false,"needs_setup":true}`,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().NeedsSetup().Return(true, nil)
 				a.EXPECT().IsSignupAllowed().Return(false)
@@ -105,9 +105,9 @@ func TestRouter_needsSetup(t *testing.T) {
 		{
 			Name:           "setup already done",
 			Method:         http.MethodGet,
-			Target:         "/setup/status",
+			Target:         setupStatusPath,
 			ExpectedStatus: http.StatusOK,
-			ExpectedBody:   `{"needs_setup":false,"allow_signup":true}`,
+			ExpectedBody:   `{"allow_signup":true,"needs_setup":false}`,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().NeedsSetup().Return(false, nil)
 				a.EXPECT().IsSignupAllowed().Return(true)
@@ -116,7 +116,7 @@ func TestRouter_needsSetup(t *testing.T) {
 		{
 			Name:           "error checking setup",
 			Method:         http.MethodGet,
-			Target:         "/setup/status",
+			Target:         setupStatusPath,
 			ExpectedStatus: http.StatusInternalServerError,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().NeedsSetup().Return(false, errors.New("db error"))
@@ -139,9 +139,9 @@ func TestRouter_getSettings(t *testing.T) {
 		{
 			Name:           "get settings",
 			Method:         http.MethodGet,
-			Target:         "/settings",
+			Target:         settingsPath,
 			ExpectedStatus: http.StatusOK,
-			ExpectedBody:   `{"allow_signup":true}`,
+			ExpectedBody:   respAllowSignupTrue,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().GetSession("test").Return(testSession(), nil)
 				a.EXPECT().IsSignupAllowed().Return(true)
@@ -164,10 +164,10 @@ func TestRouter_updateSettings(t *testing.T) {
 		{
 			Name:           "update settings - allow signup",
 			Method:         http.MethodPut,
-			Target:         "/settings",
-			ReqBody:        `{"allow_signup":true}`,
+			Target:         settingsPath,
+			ReqBody:        respAllowSignupTrue,
 			ExpectedStatus: http.StatusOK,
-			ExpectedBody:   `{"allow_signup":true}`,
+			ExpectedBody:   respAllowSignupTrue,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().GetSession("test").Return(testSession(), nil)
 				a.EXPECT().SetAllowSignup(true).Return(nil)
@@ -176,10 +176,10 @@ func TestRouter_updateSettings(t *testing.T) {
 		{
 			Name:           "update settings - disable signup",
 			Method:         http.MethodPut,
-			Target:         "/settings",
-			ReqBody:        `{"allow_signup":false}`,
+			Target:         settingsPath,
+			ReqBody:        respAllowSignupFalse,
 			ExpectedStatus: http.StatusOK,
-			ExpectedBody:   `{"allow_signup":false}`,
+			ExpectedBody:   respAllowSignupFalse,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().GetSession("test").Return(testSession(), nil)
 				a.EXPECT().SetAllowSignup(false).Return(nil)
@@ -188,8 +188,8 @@ func TestRouter_updateSettings(t *testing.T) {
 		{
 			Name:           "update settings - error",
 			Method:         http.MethodPut,
-			Target:         "/settings",
-			ReqBody:        `{"allow_signup":true}`,
+			Target:         settingsPath,
+			ReqBody:        respAllowSignupTrue,
 			ExpectedStatus: http.StatusInternalServerError,
 			MockFn: func(_ *mocks.ItemService, _ *mocks.FeedService, a *mocks.AuthService) {
 				a.EXPECT().GetSession("test").Return(testSession(), nil)

--- a/internal/infra/http/api/test_consts_test.go
+++ b/internal/infra/http/api/test_consts_test.go
@@ -5,18 +5,23 @@ const (
 	tcServiceErr    = "service returns error"
 	tcInvalidFeedID = "invalid feed id"
 
-	feedsPath     = "/feeds"
-	feed1Path     = "/feeds/1"
-	feedFetchPath = "/feeds/1/fetch"
-	item1Path     = "/items/1"
-	signupPath    = "/signup"
+	feedsPath       = "/feeds"
+	feed1Path       = "/feeds/1"
+	feedFetchPath   = "/feeds/1/fetch"
+	item1Path       = "/items/1"
+	signupPath      = "/signup"
+	setupPath       = "/setup"
+	setupStatusPath = "/setup/status"
+	settingsPath    = "/settings"
 
 	feedTitle = "title"
 	feedDesc  = "description"
 	feedLink  = "link"
 	feedDir   = "dir"
 
-	respInvalidFeedID  = `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`
-	respInternalUnread = `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`
-	respInvalidReqBody = `{"error":{"code":400,"details":"Bad Request - invalid request body"}}`
+	respInvalidFeedID    = `{"error":{"code":422,"details":"Invalid params - invalid feed id"}}`
+	respInternalUnread   = `{"error":{"code":500, "details":"Internal error - cannot get unread items"}}`
+	respInvalidReqBody   = `{"error":{"code":400,"details":"Bad Request - invalid request body"}}`
+	respAllowSignupTrue  = `{"allow_signup":true}`
+	respAllowSignupFalse = `{"allow_signup":false}`
 )

--- a/internal/infra/sqlite/auth/auth.go
+++ b/internal/infra/sqlite/auth/auth.go
@@ -32,8 +32,8 @@ func NewDB(client *sql.DB) *DB {
 func (d *DB) GetUserByEmail(email string) (*auth.User, error) {
 	var user auth.User
 	err := d.sqliteDB.
-		QueryRowContext(context.Background(), "SELECT id, email, password FROM users WHERE email = ?", email).
-		Scan(&user.ID, &user.Email, &user.Password)
+		QueryRowContext(context.Background(), "SELECT id, email, password, is_admin FROM users WHERE email = ?", email).
+		Scan(&user.ID, &user.Email, &user.Password, &user.IsAdmin)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +45,13 @@ func (d *DB) CreateUser(email, password string) error {
 	return err
 }
 
+func (d *DB) CreateAdmin(email, password string) error {
+	_, err := d.sqliteDB.ExecContext(context.Background(), "INSERT INTO users (email, password, is_admin) VALUES (?, ?, 1)", email, password)
+	return err
+}
+
 func (d *DB) GetAllUsers() ([]*auth.User, error) {
-	rows, err := d.sqliteDB.QueryContext(context.Background(), "SELECT id, email, password FROM users")
+	rows, err := d.sqliteDB.QueryContext(context.Background(), "SELECT id, email, password, is_admin FROM users")
 	if err != nil {
 		return nil, err
 	}
@@ -60,13 +65,38 @@ func (d *DB) GetAllUsers() ([]*auth.User, error) {
 	users := make([]*auth.User, 0)
 	for rows.Next() {
 		var user auth.User
-		if err := rows.Scan(&user.ID, &user.Email, &user.Password); err != nil {
+		if err := rows.Scan(&user.ID, &user.Email, &user.Password, &user.IsAdmin); err != nil {
 			return nil, err
 		}
 		users = append(users, &user)
 	}
 
 	return users, nil
+}
+
+func (d *DB) CountUsers() (int, error) {
+	var count int
+	err := d.sqliteDB.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM users").Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (d *DB) GetSetting(key string) (string, error) {
+	var value string
+	err := d.sqliteDB.QueryRowContext(context.Background(), "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
+	if err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func (d *DB) SetSetting(key, value string) error {
+	_, err := d.sqliteDB.ExecContext(context.Background(),
+		"INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+		key, value)
+	return err
 }
 
 func (d *DB) Login(f *auth.LoginCommand) error {

--- a/internal/infra/sqlite/migrations/20240201000000_add_admin_and_settings.sql
+++ b/internal/infra/sqlite/migrations/20240201000000_add_admin_and_settings.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO settings (key, value) VALUES ('allow_signup', 'false');
+
+-- +goose Down
+-- SQLite does not support DROP COLUMN, so we recreate the table
+CREATE TABLE users_backup (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO users_backup SELECT id, email, password, created_at FROM users;
+DROP TABLE users;
+ALTER TABLE users_backup RENAME TO users;
+
+DROP TABLE IF EXISTS settings;

--- a/internal/mocks/app/auth/repo_mock.go
+++ b/internal/mocks/app/auth/repo_mock.go
@@ -12,9 +12,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	auth "github.com/cubny/lite-reader/internal/app/auth"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // Repository is a mock of Repository interface.
@@ -39,6 +38,35 @@ func NewRepository(ctrl *gomock.Controller) *Repository {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *Repository) EXPECT() *RepositoryMockRecorder {
 	return m.recorder
+}
+
+// CountUsers mocks base method.
+func (m *Repository) CountUsers() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountUsers")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountUsers indicates an expected call of CountUsers.
+func (mr *RepositoryMockRecorder) CountUsers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsers", reflect.TypeOf((*Repository)(nil).CountUsers))
+}
+
+// CreateAdmin mocks base method.
+func (m *Repository) CreateAdmin(email, password string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAdmin", email, password)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateAdmin indicates an expected call of CreateAdmin.
+func (mr *RepositoryMockRecorder) CreateAdmin(email, password any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAdmin", reflect.TypeOf((*Repository)(nil).CreateAdmin), email, password)
 }
 
 // CreateSession mocks base method.
@@ -100,6 +128,21 @@ func (mr *RepositoryMockRecorder) GetSessionByToken(token any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionByToken", reflect.TypeOf((*Repository)(nil).GetSessionByToken), token)
 }
 
+// GetSetting mocks base method.
+func (m *Repository) GetSetting(key string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSetting", key)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSetting indicates an expected call of GetSetting.
+func (mr *RepositoryMockRecorder) GetSetting(key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSetting", reflect.TypeOf((*Repository)(nil).GetSetting), key)
+}
+
 // GetUserByEmail mocks base method.
 func (m *Repository) GetUserByEmail(email string) (*auth.User, error) {
 	m.ctrl.T.Helper()
@@ -113,4 +156,18 @@ func (m *Repository) GetUserByEmail(email string) (*auth.User, error) {
 func (mr *RepositoryMockRecorder) GetUserByEmail(email any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByEmail", reflect.TypeOf((*Repository)(nil).GetUserByEmail), email)
+}
+
+// SetSetting mocks base method.
+func (m *Repository) SetSetting(key, value string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetSetting", key, value)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetSetting indicates an expected call of SetSetting.
+func (mr *RepositoryMockRecorder) SetSetting(key, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSetting", reflect.TypeOf((*Repository)(nil).SetSetting), key, value)
 }

--- a/internal/mocks/app/feed/repo_mock.go
+++ b/internal/mocks/app/feed/repo_mock.go
@@ -12,9 +12,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	feed "github.com/cubny/lite-reader/internal/app/feed"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // Repository is a mock of Repository interface.
@@ -42,18 +41,18 @@ func (m *Repository) EXPECT() *RepositoryMockRecorder {
 }
 
 // AddFeed mocks base method.
-func (m *Repository) AddFeed(feed *feed.Feed) (int, error) {
+func (m *Repository) AddFeed(arg0 *feed.Feed) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddFeed", feed)
+	ret := m.ctrl.Call(m, "AddFeed", arg0)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddFeed indicates an expected call of AddFeed.
-func (mr *RepositoryMockRecorder) AddFeed(feed any) *gomock.Call {
+func (mr *RepositoryMockRecorder) AddFeed(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFeed", reflect.TypeOf((*Repository)(nil).AddFeed), feed)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFeed", reflect.TypeOf((*Repository)(nil).AddFeed), arg0)
 }
 
 // DeleteFeed mocks base method.

--- a/internal/mocks/app/item/repo_mock.go
+++ b/internal/mocks/app/item/repo_mock.go
@@ -12,9 +12,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	item "github.com/cubny/lite-reader/internal/app/item"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // Repository is a mock of Repository interface.

--- a/internal/mocks/infra/http/api/auth_mock.go
+++ b/internal/mocks/infra/http/api/auth_mock.go
@@ -12,9 +12,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	auth "github.com/cubny/lite-reader/internal/app/auth"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // AuthService is a mock of AuthService interface.
@@ -71,6 +70,20 @@ func (mr *AuthServiceMockRecorder) GetSession(token any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSession", reflect.TypeOf((*AuthService)(nil).GetSession), token)
 }
 
+// IsSignupAllowed mocks base method.
+func (m *AuthService) IsSignupAllowed() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSignupAllowed")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSignupAllowed indicates an expected call of IsSignupAllowed.
+func (mr *AuthServiceMockRecorder) IsSignupAllowed() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSignupAllowed", reflect.TypeOf((*AuthService)(nil).IsSignupAllowed))
+}
+
 // Login mocks base method.
 func (m *AuthService) Login(command *auth.LoginCommand) (*auth.LoginResponse, error) {
 	m.ctrl.T.Helper()
@@ -84,6 +97,49 @@ func (m *AuthService) Login(command *auth.LoginCommand) (*auth.LoginResponse, er
 func (mr *AuthServiceMockRecorder) Login(command any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*AuthService)(nil).Login), command)
+}
+
+// NeedsSetup mocks base method.
+func (m *AuthService) NeedsSetup() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeedsSetup")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NeedsSetup indicates an expected call of NeedsSetup.
+func (mr *AuthServiceMockRecorder) NeedsSetup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsSetup", reflect.TypeOf((*AuthService)(nil).NeedsSetup))
+}
+
+// SetAllowSignup mocks base method.
+func (m *AuthService) SetAllowSignup(allow bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetAllowSignup", allow)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetAllowSignup indicates an expected call of SetAllowSignup.
+func (mr *AuthServiceMockRecorder) SetAllowSignup(allow any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAllowSignup", reflect.TypeOf((*AuthService)(nil).SetAllowSignup), allow)
+}
+
+// Setup mocks base method.
+func (m *AuthService) Setup(command *auth.SetupCommand) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Setup", command)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Setup indicates an expected call of Setup.
+func (mr *AuthServiceMockRecorder) Setup(command any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Setup", reflect.TypeOf((*AuthService)(nil).Setup), command)
 }
 
 // Signup mocks base method.

--- a/internal/mocks/infra/http/api/feed_mock.go
+++ b/internal/mocks/infra/http/api/feed_mock.go
@@ -12,10 +12,9 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	feed "github.com/cubny/lite-reader/internal/app/feed"
 	item "github.com/cubny/lite-reader/internal/app/item"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // FeedService is a mock of FeedService interface.

--- a/internal/mocks/infra/http/api/item_mock.go
+++ b/internal/mocks/infra/http/api/item_mock.go
@@ -12,9 +12,8 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	item "github.com/cubny/lite-reader/internal/app/item"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // ItemService is a mock of ItemService interface.

--- a/internal/mocks/infra/job/dependencies_mock.go
+++ b/internal/mocks/infra/job/dependencies_mock.go
@@ -12,11 +12,10 @@ package mocks
 import (
 	reflect "reflect"
 
-	gomock "go.uber.org/mock/gomock"
-
 	auth "github.com/cubny/lite-reader/internal/app/auth"
 	feed "github.com/cubny/lite-reader/internal/app/feed"
 	item "github.com/cubny/lite-reader/internal/app/item"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // FeedService is a mock of FeedService interface.

--- a/internal/web/public/js/api/auth.js
+++ b/internal/web/public/js/api/auth.js
@@ -18,6 +18,27 @@ export async function signup({ email, password }) {
   });
 }
 
+export async function setupAdmin({ email, password, confirm_password, allow_signup }) {
+  return request('POST', '/setup', {
+    body: { email, password, confirm_password, allow_signup },
+    auth: false,
+  });
+}
+
+export async function checkNeedsSetup() {
+  return request('GET', '/setup/status', { auth: false });
+}
+
+export async function getSettings() {
+  return request('GET', '/settings');
+}
+
+export async function updateSettings({ allow_signup }) {
+  return request('PUT', '/settings', {
+    body: { allow_signup },
+  });
+}
+
 export function logout() {
   clearToken();
   location.assign('/login.html');

--- a/internal/web/public/js/pages/LoginPage.js
+++ b/internal/web/public/js/pages/LoginPage.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 
 import { html } from '../util/html.js';
-import { login } from '../api/auth.js';
+import { login, checkNeedsSetup } from '../api/auth.js';
 
 export function LoginPage() {
   const [email, setEmail] = useState('');
@@ -9,12 +9,29 @@ export function LoginPage() {
   const [error, setError] = useState('');
   const [pending, setPending] = useState(false);
   const [signupSuccess, setSignupSuccess] = useState(false);
+  const [setupSuccess, setSetupSuccess] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [allowSignup, setAllowSignup] = useState(false);
 
   useEffect(() => {
-    if (sessionStorage.getItem('signupSuccess') === 'true') {
-      setSignupSuccess(true);
-      sessionStorage.removeItem('signupSuccess');
-    }
+    checkNeedsSetup().then((data) => {
+      if (data.needs_setup) {
+        location.assign('/setup.html');
+        return;
+      }
+      setAllowSignup(data.allow_signup === true);
+      if (sessionStorage.getItem('signupSuccess') === 'true') {
+        setSignupSuccess(true);
+        sessionStorage.removeItem('signupSuccess');
+      }
+      if (sessionStorage.getItem('setupSuccess') === 'true') {
+        setSetupSuccess(true);
+        sessionStorage.removeItem('setupSuccess');
+      }
+      setLoading(false);
+    }).catch(() => {
+      setLoading(false);
+    });
   }, []);
 
   async function onSubmit(e) {
@@ -30,11 +47,20 @@ export function LoginPage() {
     }
   }
 
+  if (loading) {
+    return html`<div class="login-container"><p style="text-align:center;">Loading...</p></div>`;
+  }
+
   return html`
     <div class="login-container">
       ${signupSuccess && html`
         <aside data-testid="signup-success" class="alert alert-success">
           Account created successfully. Please log in.
+        </aside>
+      `}
+      ${setupSuccess && html`
+        <aside data-testid="setup-success" class="alert alert-success">
+          Admin account created. Please log in.
         </aside>
       `}
       <h1>Login to Lite Reader</h1>
@@ -73,9 +99,11 @@ export function LoginPage() {
         >Login</button>
         <div class="error-message" data-testid="login-error" role="alert">${error}</div>
       </form>
-      <div style="text-align: center; margin-top: 20px;">
-        <a href="/signup.html" style="color: #6C8A46;">Don't have an account? Sign up</a>
-      </div>
+      ${allowSignup && html`
+        <div style="text-align: center; margin-top: 20px;">
+          <a href="/signup.html" style="color: #6C8A46;">Don't have an account? Sign up</a>
+        </div>
+      `}
     </div>
   `;
 }

--- a/internal/web/public/js/pages/SetupPage.js
+++ b/internal/web/public/js/pages/SetupPage.js
@@ -1,29 +1,26 @@
 import { useState, useEffect } from 'preact/hooks';
 
 import { html } from '../util/html.js';
-import { signup, checkNeedsSetup } from '../api/auth.js';
+import { setupAdmin, checkNeedsSetup } from '../api/auth.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-export function SignupPage() {
+export function SetupPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
+  const [allowSignup, setAllowSignup] = useState(false);
   const [error, setError] = useState('');
   const [pending, setPending] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     checkNeedsSetup().then((data) => {
-      if (data.needs_setup) {
-        location.assign('/setup.html');
-        return;
-      }
-      if (!data.allow_signup) {
+      if (!data.needs_setup) {
         location.assign('/login.html');
-        return;
+      } else {
+        setLoading(false);
       }
-      setLoading(false);
     }).catch(() => {
       setLoading(false);
     });
@@ -31,7 +28,7 @@ export function SignupPage() {
 
   function validate() {
     if (!EMAIL_RE.test(email.trim())) return 'Please enter a valid email address';
-    if (!password || password.length < 6) return 'Password must be at least 6 characters long';
+    if (!password || password.length < 8) return 'Password must be at least 8 characters long';
     if (password !== confirm) return 'Passwords do not match';
     return '';
   }
@@ -46,11 +43,16 @@ export function SignupPage() {
     setError('');
     setPending(true);
     try {
-      await signup({ email: email.trim(), password });
-      sessionStorage.setItem('signupSuccess', 'true');
+      await setupAdmin({
+        email: email.trim(),
+        password,
+        confirm_password: confirm,
+        allow_signup: allowSignup,
+      });
+      sessionStorage.setItem('setupSuccess', 'true');
       location.assign('/login.html');
     } catch (err) {
-      setError(err.message || 'Error creating account.');
+      setError(err.message || 'Setup failed');
       setPending(false);
     }
   }
@@ -61,8 +63,11 @@ export function SignupPage() {
 
   return html`
     <div class="login-container">
-      <h1>Sign Up for Lite Reader</h1>
-      <form class="login-form" novalidate onSubmit=${onSubmit} data-testid="signup-form">
+      <h1>Welcome to Lite Reader</h1>
+      <p style="text-align: center; color: #6e6a60; margin-bottom: 20px; font-size: 14px;">
+        Create your admin account to get started.
+      </p>
+      <form class="login-form" novalidate onSubmit=${onSubmit} data-testid="setup-form">
         <div class="form-group">
           <label for="email">Email:</label>
           <input
@@ -70,7 +75,7 @@ export function SignupPage() {
             id="email"
             name="email"
             class="form-control"
-            data-testid="signup-email"
+            data-testid="setup-email"
             value=${email}
             onInput=${(e) => setEmail(e.target.value)}
             required
@@ -83,7 +88,7 @@ export function SignupPage() {
             id="password"
             name="password"
             class="form-control"
-            data-testid="signup-password"
+            data-testid="setup-password"
             value=${password}
             onInput=${(e) => setPassword(e.target.value)}
             required
@@ -96,23 +101,34 @@ export function SignupPage() {
             id="confirm-password"
             name="confirm-password"
             class="form-control"
-            data-testid="signup-confirm-password"
+            data-testid="setup-confirm-password"
             value=${confirm}
             onInput=${(e) => setConfirm(e.target.value)}
             required
           />
         </div>
+        <div class="form-group" style="flex-direction: row; align-items: center; gap: 8px; margin-top: 4px;">
+          <input
+            type="checkbox"
+            id="allow-signup"
+            data-testid="setup-allow-signup"
+            checked=${allowSignup}
+            onChange=${(e) => setAllowSignup(e.target.checked)}
+            style="width: auto;"
+          />
+          <label for="allow-signup" style="font-size: 14px; color: #2a2a28;">
+            Allow other people to create accounts
+          </label>
+        </div>
         <button
           type="submit"
           class="btn-primary"
-          data-testid="signup-submit"
+          data-testid="setup-submit"
           disabled=${pending}
-        >Sign Up</button>
-        <div class="error-message" data-testid="signup-error" role="alert">${error}</div>
+          style="margin-top: 10px;"
+        >Create Account</button>
+        <div class="error-message" data-testid="setup-error" role="alert">${error}</div>
       </form>
-      <div style="text-align: center; margin-top: 20px;">
-        <a href="/login.html" style="color: #6C8A46;">Already have an account? Log in</a>
-      </div>
     </div>
   `;
 }

--- a/internal/web/public/js/setup.js
+++ b/internal/web/public/js/setup.js
@@ -1,0 +1,7 @@
+import { render } from 'preact';
+
+import { html } from './util/html.js';
+import { SetupPage } from './pages/SetupPage.js';
+
+const root = document.getElementById('app');
+render(html`<${SetupPage} />`, root);

--- a/internal/web/public/setup.html
+++ b/internal/web/public/setup.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Setup - Lite Reader</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' rx='3' fill='%236C8A46'/%3E%3Ctext x='8' y='12' text-anchor='middle' font-family='Arial' font-weight='bold' font-size='11' fill='white'%3EL%3C/text%3E%3C/svg%3E" />
+    <link rel="stylesheet" type="text/css" href="css/auth.css">
+    <script type="importmap">
+    {
+      "imports": {
+        "preact": "/assets/vendor/preact@10.24.3/preact.module.js",
+        "preact/hooks": "/assets/vendor/preact@10.24.3/hooks.module.js",
+        "@preact/signals": "/assets/vendor/preact@10.24.3/signals.module.js",
+        "@preact/signals-core": "/assets/vendor/preact@10.24.3/signals-core.module.js",
+        "htm": "/assets/vendor/htm@3.1.1/htm.module.js"
+      }
+    }
+    </script>
+</head>
+<body>
+    <div id="app"></div>
+    <script type="module" src="js/setup.js"></script>
+</body>
+</html>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,6 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests/ui',
+  globalSetup: './tests/ui/global-setup.js',
   
   // Maximum time one test can run
   timeout: 30 * 1000,

--- a/tests/ui/global-setup.js
+++ b/tests/ui/global-setup.js
@@ -1,0 +1,48 @@
+/**
+ * Global setup for UI tests.
+ * Runs the setup wizard to create the initial admin user and enable signups
+ * so that existing test flows (which create users via the signup page) continue to work.
+ */
+
+import { request } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const ADMIN_EMAIL = 'admin@test.example';
+const ADMIN_PASSWORD = 'AdminPassword123!';
+
+export default async function globalSetup() {
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+
+  // Check if setup is needed
+  const statusResp = await ctx.get('/setup/status');
+  const status = await statusResp.json();
+
+  if (status.needs_setup) {
+    // Run setup wizard: create admin and allow signups for test users
+    const setupResp = await ctx.post('/setup', {
+      data: {
+        email: ADMIN_EMAIL,
+        password: ADMIN_PASSWORD,
+        confirm_password: ADMIN_PASSWORD,
+        allow_signup: true,
+      },
+    });
+
+    if (!setupResp.ok()) {
+      throw new Error(`Setup failed: ${setupResp.status()} ${await setupResp.text()}`);
+    }
+  } else if (!status.allow_signup) {
+    // Setup already done but signup disabled — enable it for tests
+    const loginResp = await ctx.post('/login', {
+      data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    });
+    const loginData = await loginResp.json();
+
+    await ctx.put('/settings', {
+      data: { allow_signup: true },
+      headers: { Authorization: `Bearer ${loginData.access_token}` },
+    });
+  }
+
+  await ctx.dispose();
+}


### PR DESCRIPTION
## Summary

- When the app starts with zero users, a **setup wizard** at `/setup.html` guides the admin through creating their account and choosing whether to allow public registration
- The **signup page** and login "Sign up" link are **hidden when registration is disabled**
- The admin can toggle registration on/off via `PUT /settings` (authenticated)

## Changes

### Backend
- **Migration**: adds `is_admin` column to `users`, creates `settings` table with `allow_signup` default `false`
- **Auth service**: new `Setup()`, `NeedsSetup()`, `IsSignupAllowed()`, `SetAllowSignup()` methods
- **Signup guard**: `POST /signup` now checks `allow_signup` setting and returns 403 when disabled
- **New endpoints**: `POST /setup`, `GET /setup/status`, `GET /settings`, `PUT /settings`
- **Middleware**: `/setup` and `/setup/status` skip auth
- **Cleanup**: removed dead `Auth` config struct (`AUTH_EMAIL`/`AUTH_PASSWORD` env vars that were never wired)

### Frontend
- **Setup wizard page** (`setup.html`, `SetupPage.js`): email, password, confirm, "Allow others to sign up?" checkbox
- **Login page**: checks `/setup/status` on load — redirects to setup if needed, hides signup link when disabled
- **Signup page**: checks `/setup/status` on load — redirects to login when signup is disabled

### Tests
- Service-level tests for `Setup`, `NeedsSetup`, `IsSignupAllowed`, `SetAllowSignup`, and `Signup` with signup guard
- HTTP handler tests for all 4 new endpoints
- All existing tests updated and passing

## How to test

1. Delete `data/agg.db` and run `make run`
2. Open `http://localhost:3000` — should redirect to setup wizard
3. Create admin account with "Allow others to sign up" **unchecked**
4. After login, verify the signup link is hidden and `/signup.html` redirects to login
5. Use `PUT /settings` with `{"allow_signup": true}` to enable registration, verify signup link appears