### PR TITLE
Fix Dockerfile: drop stale public/ COPY

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,6 +82,19 @@ jobs:
       - name: Run tests
         run: make test
 
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: lite-reader:ci
+
   tests-on-unix:
     needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -installsuffix cgo -o lite-
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /go/lite-reader/public ./public
 COPY --from=builder /go/lite-reader/lite-reader .
 
 # Directory to store the data, which can be referenced as the mounting point.


### PR DESCRIPTION
## Summary
- Frontend assets are now embedded into the Go binary via `//go:embed all:public` in `internal/web/web.go`; the repo root no longer contains a `public/` directory.
- The stale `COPY --from=builder /go/lite-reader/public ./public` line was failing fly.io image builds with `"/go/lite-reader/public": not found`.

## Test plan
- [ ] `flyctl deploy` builds and pushes the image successfully
- [ ] Deployed app serves the embedded frontend at `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)