### PR TITLE
Fix spurious logout on fly.io caused by SQLITE_BUSY

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ primary_region = 'ams'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[mounts]]

--- a/internal/app.go
+++ b/internal/app.go
@@ -112,7 +112,11 @@ func (a *App) initDBFile() *App {
 func (a *App) initSQLClient() *App {
 	return a.ifNoError(func() *App {
 		var sqlClient *sql.DB
-		if sqlClient, a.err = sql.Open("sqlite", a.cfg.DB.Path); a.err != nil {
+		// WAL + a generous busy_timeout are required when the DB lives on
+		// slower storage (e.g. Fly.io volumes); without them, concurrent
+		// requests hit SQLITE_BUSY and surface to callers as generic errors.
+		dsn := a.cfg.DB.Path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)"
+		if sqlClient, a.err = sql.Open("sqlite", dsn); a.err != nil {
 			a.err = fmt.Errorf("failed to open db: %w", a.err)
 			return a
 		}

--- a/internal/app.go
+++ b/internal/app.go
@@ -115,7 +115,10 @@ func (a *App) initSQLClient() *App {
 		// WAL + a generous busy_timeout are required when the DB lives on
 		// slower storage (e.g. Fly.io volumes); without them, concurrent
 		// requests hit SQLITE_BUSY and surface to callers as generic errors.
-		dsn := a.cfg.DB.Path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)"
+		// busy_timeout must be set first so the journal_mode(WAL) PRAGMA on
+		// each newly opened pooled connection also waits on a held lock
+		// instead of failing immediately.
+		dsn := a.cfg.DB.Path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)"
 		if sqlClient, a.err = sql.Open("sqlite", dsn); a.err != nil {
 			a.err = fmt.Errorf("failed to open db: %w", a.err)
 			return a

--- a/internal/infra/http/api/middleware/middleware.go
+++ b/internal/infra/http/api/middleware/middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -76,7 +77,25 @@ func AuthMiddleware(authService AuthService) HandleFunc {
 			}
 
 			session, err := authService.GetSession(token)
-			if err != nil || session == nil {
+			if err != nil {
+				// Only treat "row not found" as an auth failure; transient
+				// DB errors (e.g. SQLITE_BUSY on slow volumes) must not
+				// log the user out.
+				if errors.Is(err, sql.ErrNoRows) {
+					writeUnauthorizedResponse(w, "Unauthorized - Invalid token")
+					return
+				}
+				log.WithError(err).Error("auth: session lookup failed")
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{
+						"code":    http.StatusInternalServerError,
+						"details": "session lookup failed",
+					},
+				})
+				return
+			}
+			if session == nil {
 				writeUnauthorizedResponse(w, "Unauthorized - Invalid token")
 				return
 			}

--- a/internal/infra/http/api/middleware/middleware_test.go
+++ b/internal/infra/http/api/middleware/middleware_test.go
@@ -22,6 +22,8 @@ func (f *fakeAuthService) GetSession(string) (*auth.Session, error) {
 	return f.session, f.err
 }
 
+const bearerToken = "Bearer tok"
+
 func TestAuthMiddleware(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -38,25 +40,25 @@ func TestAuthMiddleware(t *testing.T) {
 		},
 		{
 			name:       "session not found returns 401",
-			authHeader: "Bearer tok",
+			authHeader: bearerToken,
 			svc:        &fakeAuthService{err: sql.ErrNoRows},
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:       "nil session returns 401",
-			authHeader: "Bearer tok",
+			authHeader: bearerToken,
 			svc:        &fakeAuthService{},
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:       "transient DB error returns 500, not 401",
-			authHeader: "Bearer tok",
+			authHeader: bearerToken,
 			svc:        &fakeAuthService{err: errors.New("database is locked (SQLITE_BUSY)")},
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
 			name:       "valid session calls next",
-			authHeader: "Bearer tok",
+			authHeader: bearerToken,
 			svc:        &fakeAuthService{session: &auth.Session{UserID: 42}},
 			wantStatus: http.StatusOK,
 			wantNext:   true,
@@ -76,7 +78,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 			handler := AuthMiddleware(tt.svc)(next)
 
-			req := httptest.NewRequest(http.MethodGet, "/feeds", nil)
+			req := httptest.NewRequest(http.MethodGet, "/feeds", http.NoBody)
 			if tt.authHeader != "" {
 				req.Header.Set("Authorization", tt.authHeader)
 			}
@@ -105,7 +107,7 @@ func TestAuthMiddlewareSkipsPublicPaths(t *testing.T) {
 			// the auth check entirely.
 			handler := AuthMiddleware(&fakeAuthService{err: sql.ErrNoRows})(next)
 
-			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req := httptest.NewRequest(http.MethodPost, path, http.NoBody)
 			rec := httptest.NewRecorder()
 			handler(rec, req, nil)
 

--- a/internal/infra/http/api/middleware/middleware_test.go
+++ b/internal/infra/http/api/middleware/middleware_test.go
@@ -1,0 +1,117 @@
+package middleware
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/cubny/lite-reader/internal/app/auth"
+	"github.com/cubny/lite-reader/internal/infra/http/api/cxutil"
+)
+
+type fakeAuthService struct {
+	session *auth.Session
+	err     error
+}
+
+func (f *fakeAuthService) GetSession(string) (*auth.Session, error) {
+	return f.session, f.err
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	tests := []struct {
+		name       string
+		authHeader string
+		svc        *fakeAuthService
+		wantStatus int
+		wantNext   bool
+	}{
+		{
+			name:       "missing token",
+			authHeader: "",
+			svc:        &fakeAuthService{},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "session not found returns 401",
+			authHeader: "Bearer tok",
+			svc:        &fakeAuthService{err: sql.ErrNoRows},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "nil session returns 401",
+			authHeader: "Bearer tok",
+			svc:        &fakeAuthService{},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "transient DB error returns 500, not 401",
+			authHeader: "Bearer tok",
+			svc:        &fakeAuthService{err: errors.New("database is locked (SQLITE_BUSY)")},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "valid session calls next",
+			authHeader: "Bearer tok",
+			svc:        &fakeAuthService{session: &auth.Session{UserID: 42}},
+			wantStatus: http.StatusOK,
+			wantNext:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+				nextCalled = true
+				if uid, ok := r.Context().Value(cxutil.UserIDKey).(int); !ok || uid != 42 {
+					t.Errorf("expected userID 42 in context, got %v (ok=%v)", uid, ok)
+				}
+				w.WriteHeader(http.StatusOK)
+			}
+
+			handler := AuthMiddleware(tt.svc)(next)
+
+			req := httptest.NewRequest(http.MethodGet, "/feeds", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			handler(rec, req, nil)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status: got %d, want %d", rec.Code, tt.wantStatus)
+			}
+			if nextCalled != tt.wantNext {
+				t.Errorf("next called: got %v, want %v", nextCalled, tt.wantNext)
+			}
+		})
+	}
+}
+
+func TestAuthMiddlewareSkipsPublicPaths(t *testing.T) {
+	for _, path := range []string{"/login", "/signup", "/setup", "/setup/status"} {
+		t.Run(path, func(t *testing.T) {
+			nextCalled := false
+			next := func(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			}
+			// No auth header and an erroring service: public paths must skip
+			// the auth check entirely.
+			handler := AuthMiddleware(&fakeAuthService{err: sql.ErrNoRows})(next)
+
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			rec := httptest.NewRecorder()
+			handler(rec, req, nil)
+
+			if !nextCalled {
+				t.Errorf("%s: expected next to be called", path)
+			}
+		})
+	}
+}

--- a/internal/infra/http/api/middleware/middleware_test.go
+++ b/internal/infra/http/api/middleware/middleware_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"net/http"
@@ -78,7 +79,7 @@ func TestAuthMiddleware(t *testing.T) {
 
 			handler := AuthMiddleware(tt.svc)(next)
 
-			req := httptest.NewRequest(http.MethodGet, "/feeds", http.NoBody)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/feeds", http.NoBody)
 			if tt.authHeader != "" {
 				req.Header.Set("Authorization", tt.authHeader)
 			}
@@ -107,7 +108,7 @@ func TestAuthMiddlewareSkipsPublicPaths(t *testing.T) {
 			// the auth check entirely.
 			handler := AuthMiddleware(&fakeAuthService{err: sql.ErrNoRows})(next)
 
-			req := httptest.NewRequest(http.MethodPost, path, http.NoBody)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, http.NoBody)
 			rec := httptest.NewRecorder()
 			handler(rec, req, nil)
 


### PR DESCRIPTION
## Summary
- Open SQLite with WAL + `busy_timeout=5000` + `synchronous=NORMAL` so concurrent requests on Fly volumes don't hit `SQLITE_BUSY`.
- Auth middleware now only returns 401 on `sql.ErrNoRows`; transient DB errors return 500 instead of logging the user out.
- `fly.toml`: `min_machines_running = 1` so cold-start request replays don't compound the issue.

## Why
Moving a feed to a folder on fly.io kicked the user to the login page. Reorder fan-out fires many parallel `PATCH /feeds/:id` requests; on the network volume those collide on the sessions table and SQLite returns a busy error. The middleware treated any error from `GetSession` as "invalid token" → 401 → frontend clears token → redirect to /login. Localhost on fast SSD never tripped the contention window.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Deploy to fly.io and verify moving a feed to a folder no longer logs the user out
- [ ] Verify reorder fan-out across many feeds returns 204 consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)