### PR TITLE
Add Fly.io deploy workflow triggered on release

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy to Fly.io
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never let two deploys race; a newer release supersedes an in-flight one.
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Problem

Tagging `v3.3.1` did not deploy anything to fly.io, and no new image appeared in the registry.

Root cause: **there is no fly.io deploy automation in this repo, and there never has been.**

- `release.yml` runs **goreleaser only** — it cross-compiles binaries and attaches zips to the GitHub Release. It never builds a Docker image and never contacts fly.io.
- `fly.toml` (added in 6835a08, "Fly.io Launch config files") makes `fly deploy` work *from a laptop*, but no CI step ever calls it.
- `flyctl releases` shows 5 releases, all created manually by `cubny@duck.com`, the most recent on **May 20 2026**. Production has been serving that image ever since.
- `grep -ri "flyctl|fly deploy|FLY_API_TOKEN"` across the repo returned zero hits.

The application code was never the problem — the scheduler fix landed on master as `aedd415`, and CI's `docker-build` job confirms the image builds cleanly.

## Fix

Adds `.github/workflows/fly-deploy.yml`, which runs `flyctl deploy --remote-only` on `release: created` — matching the existing `release.yml` trigger, so tagging a release now both publishes binaries and deploys. `workflow_dispatch` is included so a deploy can be re-run by hand without cutting a new release.

A `concurrency` group prevents two deploys from racing.

## Setup already done

- Created a deploy-scoped fly token `github-actions-deploy` on the `lite-reader` app, expiring **2027-07-10** (flyctl defaults to a 20-year expiry; 1 year is more appropriate for a CI credential).
- Stored it as the repo secret `FLY_API_TOKEN`.

## Verifying after merge

This workflow can't run until it's on the default branch. Once merged, trigger it manually to deploy the already-released v3.3.1:

```
gh workflow run "Deploy to Fly.io" --ref master
```

Then confirm `flyctl status --app lite-reader` reports a machine updated today rather than 2026-05-20.

Note: the deploy checks out the ref the workflow ran on. Dispatching against `master` deploys master's tip; a `release: created` run deploys the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)